### PR TITLE
Reduce instance store size to 8GB

### DIFF
--- a/src/packer.json
+++ b/src/packer.json
@@ -6,7 +6,7 @@
           "delete_on_termination": true,
           "device_name": "xvda",
           "encrypted": true,
-          "volume_size": 10,
+          "volume_size": 8,
           "volume_type": "gp2"
         }
       ],
@@ -18,7 +18,7 @@
           "delete_on_termination": true,
           "device_name": "xvda",
           "encrypted": true,
-          "volume_size": 10,
+          "volume_size": 8,
           "volume_type": "gp2"
         }
       ],


### PR DESCRIPTION
In every AMI we have built so far except for the docker AMI, 8GB was sufficiently large.  It may be possible to reduce the size further, but for now I wanted to reduce it to 8GB.  This will make the AMIs smaller and reduce the time spent waiting for them to finish encrypting.