### PR TITLE
Add support for KMS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,9 @@ env:
     3bX4KmUdPpv1mLNg5ugcp+8PWT1/Bb0U2A="
     - PACKER_BUILD_REGION="us-east-2"
     - PACKER_DEPLOY_REGIONS="us-east-1,us-west-1,us-west-2"
-    - PACKER_VERSION="1.4.2"
+    - PACKER_VERSION="1.4.3"
     - PACKER_ZIP="packer_${PACKER_VERSION}_linux_amd64.zip"
-    - TERRAFORM_VERSION="0.12.6"
+    - TERRAFORM_VERSION="0.12.7"
     - TERRAFORM_ZIP="terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,10 @@ before_deploy:
   - pip install travis-wait-improved
 
 deploy:
-  # create an image
+  # create an image when tagged
   - provider: script
+    # preserve patch to packer configuration by skipping cleanup
+    skip_cleanup: true
     script: travis-wait-improved --timeout=30m packer build --timestamp-ui
       src/packer.json
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,10 @@ env:
     yKDN3LCV3Sj6nmiE4d3UmjP/YKkQxD9cqCzBFMuUtJKgNajpbuy0WKdtkConb2wxSa\
     3bX4KmUdPpv1mLNg5ugcp+8PWT1/Bb0U2A="
     - PACKER_BUILD_REGION="us-east-2"
-    - PACKER_DEPLOY_REGIONS="us-east-1,us-west-1,us-west-2"
+    - PACKER_DEPLOY_REGION_KMS_MAP="us-east-1:alias/cool/ebs,\
+                                    us-east-2:alias/cool/ebs,\
+                                    us-west-1:alias/cool/ebs,\
+                                    us-west-2:alias/cool/ebs"
     - PACKER_VERSION="1.4.3"
     - PACKER_ZIP="packer_${PACKER_VERSION}_linux_amd64.zip"
     - TERRAFORM_VERSION="0.12.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,8 +82,8 @@ install:
   - ansible-galaxy install --force --role-file src/requirements.yml
 
 script:
-  - eval $(./update_env.py)
   - pre-commit run --all-files
+  - ./patch_packer_config.py src/packer.json
   - packer validate src/packer.json
   - pytest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ env:
     yKDN3LCV3Sj6nmiE4d3UmjP/YKkQxD9cqCzBFMuUtJKgNajpbuy0WKdtkConb2wxSa\
     3bX4KmUdPpv1mLNg5ugcp+8PWT1/Bb0U2A="
     - PACKER_BUILD_REGION="us-east-2"
-    - PACKER_DEPLOY_REGION_KMS_MAP="us-east-1:alias/cool/ebs,\
-                                    us-east-2:alias/cool/ebs,\
-                                    us-west-1:alias/cool/ebs,\
+    - PACKER_DEPLOY_REGION_KMS_MAP="us-east-1:alias/cool/ebs,
+                                    us-east-2:alias/cool/ebs,
+                                    us-west-1:alias/cool/ebs,
                                     us-west-2:alias/cool/ebs"
     - PACKER_VERSION="1.4.3"
     - PACKER_ZIP="packer_${PACKER_VERSION}_linux_amd64.zip"

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ install:
 
 script:
   - pre-commit run --all-files
-  - ./patch_packer_config.py src/packer.json
+  - ./patch_packer_config.py query-github src/packer.json
   - packer validate src/packer.json
   - pytest
 

--- a/README.md
+++ b/README.md
@@ -87,8 +87,14 @@ ansible-galaxy install --force --role-file src/requirements.yml
 packer build --timestamp-ui src/packer.json
 ```
 
-To create a release that deploys to all regions, change the `pre-release`
-command of `patch_packer_config.py` to `release` in the example above.
+If you are satisfied with your pre-release image, you can easily create a release
+that deploys to all regions by changing the `pre-release` command of
+`patch_packer_config.py` to `release` and rerunning packer:
+
+```console
+./patch_packer_config.py release src/packer.json
+packer build --timestamp-ui src/packer.json
+```
 
 See the patcher script's help for more information about its options and
 inner workings:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ how the build was triggered from GitHub.
    environment variable.
 1. **Production release deploy**: Publish a GitHub release with
    the "This is a pre-release" checkbox unchecked.  An image will be built
-   in the `PACKER_BUILD_REGION` and copied to each region listed in the
+   in the `PACKER_BUILD_REGION` and copied to each regions listed in the
    `PACKER_DEPLOY_REGION_KMS_MAP` environment variable.
 
 ### Using Your Local Environment ###

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ export PACKER_IMAGE_VERSION=$(./bump_version.sh show)
 export PACKER_PRE_RELEASE="True"
 pip install --requirement requirements-dev.txt
 ansible-galaxy install --force --role-file src/requirements.yml
+./patch_packer_config.py src/packer.json
 packer build --timestamp-ui src/packer.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Here is an example of encrypting the credentials for Travis:
 ```console
  travis encrypt --com --no-interactive "AWS_ACCESS_KEY_ID=AKIAxxxxxxxxxxxxxxxx"
  travis encrypt --com --no-interactive "AWS_SECRET_ACCESS_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+ travis encrypt --com --no-interactive "GITHUB_ACCESS_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ```
 
 ## Building the Image ##
@@ -55,8 +56,9 @@ The following environment variables are used by Packer:
   - `PACKER_BUILD_REGION`: the region in which to build the image.
   - `PACKER_DEPLOY_REGION_KMS_MAP`: a map of deploy regions to KMS keys.
 - Optional
+  - `GITHUB_ACCESS_TOKEN`: a personal GitHub token to use for API access.
   - `PACKER_IMAGE_VERSION`: the version tag applied to the final image.
-  - `PACKER_PRE_RELEASE`: a boolean tag applied to the final image
+  - `PACKER_PRE_RELEASE`: a boolean tag applied to the final image.
 
 Here is an example of how to kick off a build:
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,24 @@ Here is an example of encrypting the credentials for Travis:
 
 ### Using Travis-CI ###
 
-1. Create a new release in GitHub.
+1. Create a [new release](https://help.github.com/en/articles/creating-releases)
+   in GitHub.
 1. There is no step 2!
+
+Travis-CI can build this project in three different modes depending on
+how the build was triggered from GitHub.
+
+1. **Non-release test**: After a normal commit or pull request Travis
+   will build the project, and run tests and validation on the
+   packer configuration.  It will __not__ build an image.
+1. **Pre-release deploy**: Publish a GitHub release
+   with the "This is a pre-release" checkbox checked.  An image will be built
+   and deployed to the single region defined by the `PACKER_BUILD_REGION`
+   environment variable.
+1. **Production release deploy**: Publish a GitHub release with
+   the "This is a pre-release" checkbox unchecked.  An image will be built
+   in the `PACKER_BUILD_REGION` and copied to each region listed in the
+   `PACKER_DEPLOY_REGION_KMS_MAP` environment variable.
 
 ### Using Your Local Environment ###
 
@@ -58,19 +74,23 @@ The following environment variables are used by Packer:
 - Optional
   - `GITHUB_ACCESS_TOKEN`: a personal GitHub token to use for API access.
   - `PACKER_IMAGE_VERSION`: the version tag applied to the final image.
-  - `PACKER_PRE_RELEASE`: a boolean tag applied to the final image.
 
-Here is an example of how to kick off a build:
+Here is an example of how to kick off a pre-release build:
 
 ```console
+pip install --requirement requirements-dev.txt
 export PACKER_BUILD_REGION="us-east-2"
 export PACKER_DEPLOY_REGION_KMS_MAP="us-east-1:alias/cool/ebs,us-east-2:alias/cool/ebs,us-west-1:alias/cool/ebs,us-west-2:alias/cool/ebs"
 export PACKER_IMAGE_VERSION=$(./bump_version.sh show)
-export PACKER_PRE_RELEASE="True"
-pip install --requirement requirements-dev.txt
 ansible-galaxy install --force --role-file src/requirements.yml
-./patch_packer_config.py src/packer.json
+./patch_packer_config.py pre-release src/packer.json
 packer build --timestamp-ui src/packer.json
+```
+
+For other release types see:
+
+```console
+./patch_packer_config.py --help
 ```
 
 ## Contributing ##

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Here is an example of encrypting the credentials for Travis:
 The following environment variables are used by Packer:
 
 - Required
-  - `PACKER_BUILD_REGION`: the region to build the build the image in.
+  - `PACKER_BUILD_REGION`: the region in which to build the image.
+  - `PACKER_DEPLOY_REGION_KMS_MAP`: a map of deploy regions to KMS keys.
 - Optional
-  - `PACKER_DEPLOY_REGIONS`: list of additional regions to deploy this image.
   - `PACKER_IMAGE_VERSION`: the version tag applied to the final image.
   - `PACKER_PRE_RELEASE`: a boolean tag applied to the final image
 
@@ -62,7 +62,7 @@ Here is an example of how to kick off a build:
 
 ```console
 export PACKER_BUILD_REGION="us-east-2"
-export PACKER_DEPLOY_REGIONS="us-east-1,us-west-1,us-west-2"
+export PACKER_DEPLOY_REGION_KMS_MAP="us-east-1:alias/cool/ebs,us-east-2:alias/cool/ebs,us-west-1:alias/cool/ebs,us-west-2:alias/cool/ebs"
 export PACKER_IMAGE_VERSION=$(./bump_version.sh show)
 export PACKER_PRE_RELEASE="True"
 pip install --requirement requirements-dev.txt

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ how the build was triggered from GitHub.
    environment variable.
 1. **Production release deploy**: Publish a GitHub release with
    the "This is a pre-release" checkbox unchecked.  An image will be built
-   in the `PACKER_BUILD_REGION` and copied to each regions listed in the
+   in the `PACKER_BUILD_REGION` and copied to each region listed in the
    `PACKER_DEPLOY_REGION_KMS_MAP` environment variable.
 
 ### Using Your Local Environment ###
@@ -87,7 +87,11 @@ ansible-galaxy install --force --role-file src/requirements.yml
 packer build --timestamp-ui src/packer.json
 ```
 
-For other release types see:
+To create a release that deploys to all regions, change the `pre-release`
+command of `patch_packer_config.py` to `release` in the example above.
+
+See the patcher script's help for more information about its options and
+inner workings:
 
 ```console
 ./patch_packer_config.py --help

--- a/patch_packer_config.py
+++ b/patch_packer_config.py
@@ -125,12 +125,11 @@ def main():
             eprint(f"Unable to lookup pre-release status for {slug}:{tag}")
             sys.exit(-1)
 
-    if is_prerelease:
-        # This is a prerelease: no PACKER_DEPLOY_REGIONS.
-        eprint(f"{tag} is a pre-release build.")
-    else:
-        # This is a regular release: do not modify PACKER_DEPLOY_REGIONS.
-        eprint(f"{tag} is NOT a pre-release build.")
+    if tag:
+        if is_prerelease:
+            eprint(f"{tag} is a pre-release build.")
+        else:
+            eprint(f"{tag} is NOT a pre-release build.")
 
     patch_config(config_filename, build_region, kms_map, is_prerelease)
 

--- a/patch_packer_config.py
+++ b/patch_packer_config.py
@@ -14,6 +14,12 @@ See: https://developer.github.com/v3/#rate-limiting
 It reads the PACKER_BUILD_REGION and PACKER_DEPLOY_REGION_KMS_MAP environment
 variables to calculate the values in the packer configuration.
 
+It will overwrite the following sections of a packer amazon-ebs builder configuration:
+ - ami_regions
+ - region
+ - region_kms_key_ids
+ - tags/Pre_Release
+
 Example usage:
     ./patch_packer_config.py src/packer.json
 """
@@ -114,6 +120,10 @@ def main():
     tag = os.getenv("TRAVIS_TAG")
     if not tag:
         eprint("TRAVIS_TAG not set (not a release)")
+        # The config still needs to be generated correctly as
+        # it will be validated even if it isn't deployed.
+        # So we'll generate it as if it was a full release since
+        # it will test more of the configuration.
         is_prerelease = False
     else:
         try:
@@ -124,8 +134,6 @@ def main():
             # Either the slug or tag were not found.
             eprint(f"Unable to lookup pre-release status for {slug}:{tag}")
             sys.exit(-1)
-
-    if tag:
         if is_prerelease:
             eprint(f"{tag} is a pre-release build.")
         else:

--- a/patch_packer_config.py
+++ b/patch_packer_config.py
@@ -62,7 +62,7 @@ def patch_config(filename, build_region, kms_map, is_prerelease):
             continue
 
         # invariants
-        builder["tags"]["Pre_Release"] = is_prerelease
+        builder["tags"]["Pre_Release"] = str(is_prerelease)
         builder["region"] = build_region
 
         if is_prerelease:

--- a/patch_packer_config.py
+++ b/patch_packer_config.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
-"""Script to output shell commands needed to update the evironment.
+"""Modify a packer json configuration based on the build environment.
 
 This script uses the GitHub API and the TRAVIS_REPO_SLUG and TRAVIS_TAG environment
-variables to determine if the current build is a pre-release.  It will then output
-shell commands for evaulation based on the pre-release status.
+variables to determine if the current build is a pre-release.  It will then modify
+the passed in Packer configuration.
 
 When running in a Travis CI it is possible that the GitHub API call will be rate
 limited by the shared IP of all Travis users.  Setting the GITHUB_ACCESS_TOKEN
@@ -12,7 +12,7 @@ will cause this script to be limited by the token owner instead.
 See: https://developer.github.com/v3/#rate-limiting
 
 Example usage:
-    eval $(./update_env.py)
+    ./patch_packer_config.py src/packer.json
 """
 
 import os

--- a/patch_packer_config.py
+++ b/patch_packer_config.py
@@ -11,10 +11,14 @@ will cause this script to be limited by the token owner instead.
 
 See: https://developer.github.com/v3/#rate-limiting
 
+It reads the PACKER_BUILD_REGION and PACKER_DEPLOY_REGION_KMS_MAP environment
+variables to calculate the values in the packer configuration.
+
 Example usage:
     ./patch_packer_config.py src/packer.json
 """
 
+import json
 import os
 import sys
 
@@ -27,8 +31,62 @@ def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)
 
 
+def make_kms_map(map_string):
+    """Convert a string into a map."""
+    # The one line version:
+    # dict({tuple(k.split(':')) for k in [i.strip() for i in m.split(',')]})
+    result = dict()
+    # split string by comma and strip
+    lines = [i.strip() for i in map_string.split(",")]
+    for line in lines:
+        # split into key/value pairs and store
+        k, v = line.split(":")
+        result[k] = v
+    return result
+
+
+def patch_config(filename, build_region, kms_map, is_prerelease):
+    """Patch the packer configuration file."""
+    try:
+        # read and parse the packer configuration file
+        with open(filename, "r") as fp:
+            config = json.load(fp)
+    except FileNotFoundError:
+        eprint(f"Packer configuration file not found: {filename}")
+        sys.exit(-1)
+
+    # loop through all the packer builders
+    for builder in config["builders"]:
+        # only modify AWS builders
+        if builder.get("type") != "amazon-ebs":
+            continue
+
+        # invariants
+        builder["tags"]["Pre_Release"] = is_prerelease
+        builder["region"] = build_region
+
+        if is_prerelease:
+            # Pre-Release
+            builder["ami_regions"] = build_region
+            builder["region_kms_key_ids"] = {build_region: kms_map[build_region]}
+        else:
+            # Production Release
+            builder["ami_regions"] = ",".join(kms_map.keys())
+            builder["region_kms_key_ids"] = kms_map
+
+    # write the modified configuration back out
+    with open(filename, "w") as fp:
+        json.dump(config, fp, indent=2, sort_keys=True)
+
+
 def main():
     """Check pre-release flag and return value for PACKER_DEPLOY_REGIONS."""
+    try:
+        config_filename = sys.argv[1]
+    except IndexError:
+        eprint(f"Packer configuration file name not provided.")
+        sys.exit(-1)
+
     # if we have a Github access token use it, otherwise we may be rate limited
     # by all the other Travis users coming from the same IP.
     access_token = os.getenv("GITHUB_ACCESS_TOKEN")
@@ -47,6 +105,17 @@ def main():
         eprint("TRAVIS_TAG not set")
         sys.exit(-1)
 
+    build_region = os.getenv("PACKER_BUILD_REGION")
+    if not build_region:
+        eprint("PACKER_BUILD_REGION not set")
+        sys.exit(-1)
+
+    kms_map_string = os.getenv("PACKER_DEPLOY_REGION_KMS_MAP")
+    if not kms_map_string:
+        eprint("PACKER_DEPLOY_REGION_KMS_MAP not set")
+        sys.exit(-1)
+    kms_map = make_kms_map(kms_map_string)
+
     try:
         repo = g.get_repo(slug)
         release = repo.get_release(tag)
@@ -58,12 +127,11 @@ def main():
     if release.prerelease:
         # This is a prerelease: no PACKER_DEPLOY_REGIONS.
         eprint(f"{tag} is a pre-release build.")
-        print('export PACKER_DEPLOY_REGIONS=""')
-        print('export PACKER_PRE_RELEASE="True"')
     else:
         # This is a regular release: do not modify PACKER_DEPLOY_REGIONS.
         eprint(f"{tag} is NOT a pre-release build.")
-        print('export PACKER_PRE_RELEASE="False"')
+
+    patch_config(config_filename, build_region, kms_map, True)  # release.prerelease)
 
     sys.exit(0)
 

--- a/patch_packer_config.py
+++ b/patch_packer_config.py
@@ -28,10 +28,11 @@ See: https://developer.github.com/v3/#rate-limiting
 Usage:
     patch_packer_config.py (query-github|pre-release|release) <packer-json>
     patch_packer_config.py -h | --help
+    patch_packer_config.py -v | --version
 
 Options:
   -h --help              Show this message.
-
+  -v --version           Output the version of the script.
 """
 
 import json

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,3 @@
 -r requirements.txt
 pre-commit
-PyGithub
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 ansible
 boto3
+docopt
+PyGithub

--- a/src/packer.json
+++ b/src/packer.json
@@ -11,7 +11,7 @@
         }
       ],
       "ami_name": "example-hvm-{{timestamp}}-x86_64-ebs",
-      "ami_regions": "{{user `deploy_regions`}}",
+      "ami_regions": "from-patcher-script",
       "instance_type": "t3.micro",
       "launch_block_device_mappings": [
         {
@@ -22,7 +22,10 @@
           "volume_type": "gp2"
         }
       ],
-      "region": "{{user `build_region`}}",
+      "region": "from-patcher-script",
+      "region_kms_key_ids": {
+        "from-patcher-script": "from-patcher-script"
+      },
       "source_ami_filter": {
         "filters": {
           "name": "debian-stretch-hvm-x86_64-gp2-*",
@@ -39,7 +42,7 @@
         "Application": "Example",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "OS_Version": "Debian Stretch",
-        "Pre_Release": "{{user `pre_release`}}",
+        "Pre_Release": "from-patcher-script",
         "Release": "{{user `image_version`}}",
         "Team": "CISA - Development",
         "Travis_Job_Web_URL": "{{user `travis_job_web_url`}}"
@@ -59,10 +62,7 @@
   ],
   "sensitive-variables": [],
   "variables": {
-    "build_region": "{{env `PACKER_BUILD_REGION`}}",
-    "deploy_regions": "{{env `PACKER_DEPLOY_REGIONS`}}",
     "image_version": "{{env `PACKER_IMAGE_VERSION`}}",
-    "pre_release": "{{env `PACKER_PRE_RELEASE`}}",
     "travis_job_web_url": "{{env `TRAVIS_JOB_WEB_URL`}}"
   }
 }


### PR DESCRIPTION
Supports setting per-region KMS aliases.  The helper script now pre-processes the `packer.json` file instead of modifying the environment variables used by packer.  