### PR TITLE
Add go version to lint cache key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           echo "::set-env name=PY_VERSION::"\
           "$(python -c "import platform;print(platform.python_version())")"
+      - name: Store installed Go version
+        run: |
+          echo "::set-env name=GO_VERSION::"\
+          "$(go version | sed 's/^go version go\([0-9.]\+\) .*/\1/')"
       - name: Lookup go cache directory
         id: go-cache
         run: |
@@ -45,11 +49,14 @@ jobs:
             ${{ env.TF_CACHE_DIR }}
           key: "lint-${{ runner.os }}-\
             py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
             tf${{ env.TERRAFORM_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            lint-${{ runner.os }}-py${{ env.PY_VERSION }}-\
+            lint-${{ runner.os }}-\
+            py${{ env.PY_VERSION }}-\
+            go${{ env.GO_VERSION }}-\
             tf${{ env.TERRAFORM_VERSION }}-
             lint-${{ runner.os }}-
       - name: Install Terraform


### PR DESCRIPTION
## 🗣 Description

Add the go version to the lint cache key.

## 💭 Motivation and Context

Changing `go` versions should bust the linter cache, since it may result in different `go` modules being used by `pre-commit` hooks.

## 🧪 Testing

All pre-commit hooks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
