### PR TITLE
Fix Terraform caching mishaps.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,8 @@ jobs:
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \
             -type f -iname "*.tf" -exec dirname "{}" \; | sort -u); do \
-            terraform init -input=false -backend=false "$path"; \
+            echo "Initializing '$path'..."; \
+            terraform init -upgrade=true -input=false -backend=false "$path"; \
             done
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,13 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Verify Terraform installation details
         run: |
+          ls -la /usr/bin/terraform
+          ls -la /usr/local/bin/terraform
           command -v terraform
+          /usr/local/bin/terraform --version
+          /usr/bin/terraform --version
           terraform --version
+          env | grep PATH
       - name: Find and initialize Terraform directories
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
           /usr/bin/terraform --version
           terraform --version
           env | grep PATH
+      - name: Find all terraform binaries
+        run: find / -type f -iname "terraform"
       - name: Find and initialize Terraform directories
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,8 +74,8 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Find and initialize Terraform directories
         run: |
-          for path in [[ $(find . -type f -iname "*.tf" -exec dirname "{}" \; \
-            | sort -u) ]]; do \
+          for path in $(find . -not \( -type d -name ".terraform" -prune \) \
+            -type f -iname "*.tf" -exec dirname "{}" \; | sort -u); do \
             terraform init -input=false -backend=false "$path"; \
             done
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,10 @@ jobs:
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
       - name: Install Terraform-docs
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
+      - name: Verify Terraform installation details
+        run: |
+          command -v terraform
+          terraform --version
       - name: Find and initialize Terraform directories
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,15 +75,10 @@ jobs:
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Verify Terraform installation details
         run: |
-          ls -la /usr/bin/terraform
-          ls -la /usr/local/bin/terraform
           command -v terraform
           /usr/local/bin/terraform --version
           /usr/bin/terraform --version
           terraform --version
-          env | grep PATH
-      - name: Find all terraform binaries
-        run: sudo find / -type f -iname "terraform"
       - name: Find and initialize Terraform directories
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,12 +74,6 @@ jobs:
           sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
       - name: Install Terraform-docs
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
-      - name: Verify Terraform installation details
-        run: |
-          command -v terraform
-          /usr/local/bin/terraform --version
-          /usr/bin/terraform --version
-          terraform --version
       - name: Find and initialize Terraform directories
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ env:
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
-  TF_CACHE_DIR: .terraform
 
 jobs:
   lint:
@@ -41,12 +40,17 @@ jobs:
       - name: Cache linting environments
         uses: actions/cache@v2
         with:
+          # Note that the .terraform directory IS NOT included in the
+          # cache because if we were caching, then we would need to use
+          # the `-upgrade=true` option. This option blindly pulls down the
+          # latest modules and providers instead of checking to see if an
+          # update is required. That behavior defeats the benefits of caching.
+          # so there is no point in doing it for the .terraform directory.
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
             ${{ steps.go-cache.outputs.dir }}
-            ${{ env.TF_CACHE_DIR }}
           key: "lint-${{ runner.os }}-\
             py${{ env.PY_VERSION }}-\
             go${{ env.GO_VERSION }}-\
@@ -79,7 +83,7 @@ jobs:
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \
             -type f -iname "*.tf" -exec dirname "{}" \; | sort -u); do \
             echo "Initializing '$path'..."; \
-            terraform init -upgrade=true -input=false -backend=false "$path"; \
+            terraform init -input=false -backend=false "$path"; \
             done
       - name: Install dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           sudo unzip -d /opt/terraform \
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+          sudo mv /usr/local/bin/terraform /usr/local/bin/terraform-default
           sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
       - name: Install Terraform-docs
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           terraform --version
           env | grep PATH
       - name: Find all terraform binaries
-        run: find / -type f -iname "terraform"
+        run: sudo find / -type f -iname "terraform"
       - name: Find and initialize Terraform directories
         run: |
           for path in $(find . -not \( -type d -name ".terraform" -prune \) \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           sudo unzip -d /opt/terraform \
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+          sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
       - name: Install Terraform-docs
         run: GO111MODULE=on go get github.com/segmentio/terraform-docs
       - name: Verify Terraform installation details


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description

This PR fixes two issues:
1. The Terraform initialization step in the lint job of the build workflow was attempting to initialize the `.terraform` directory because it is cached. This caused runs to fail.
1. The version of Terraform we were installing is not what the system was using. We symlinked to `/usr/bin/terraform`, but `/usr/local/bin` had higher precedence in the PATH of the virtual environment. This also caused builds to fail because of version conflicts.

These are remedied by:
1. Adding "guardrails" to the initialization step so that it does not attempt to initialize a `.terraform` directory.
1. Moving the `terraform` binary that is installed on GH Actions runners at `/usr/local/bin/terraform`, and then symlink our version pinned copy.

Once this PR is approved I will make the same updates to the workflows in [cisagov/skeleton-tf-module](https://github.com/cisagov/skeleton-tf-module) and [cisagov/skeleton-ansible-role-with-test-user](https://github.com/cisagov/skeleton-ansible-role-with-test-user) since they use Terraform in the same way.


### UPDATE

After looking at [cisagov/skeleton-tf-module](https://github.com/cisagov/skeleton-tf-module) and [cisagov/skeleton-ansible-role-with-test-user](https://github.com/cisagov/skeleton-ansible-role-with-test-user), I was reminded of the rationale behind why we didn't cache the `.terraform` directory previously. As a result, I am removing `.terraform` caching and adding an explanatory comment for why. I am leaving the guardrails in because it's good to have them in case Terraform's behavior changes in the future.

Terraform code describing behavior:
https://github.com/hashicorp/terraform/blob/83630a7003fb8b868a3bf940798326634c3c6acc/command/init.go#L491-L494

<!--- Describe your changes in detail -->

## 💭 Motivation and Context

@jsf9k noticed that this project, and those descended from it, were failing [apb](https://github.com/cisagov/action-apb) triggered builds. Upon investigating, he noticed that it was initializing the `.terraform` directory. He reached out to me and I began to look into the cause. I realized that the initialization step had been written when there was no caching of the `.terraform` directory, and so lacked guardrails to prevent the observed behavior. In the course of testing the fix, I noticed that the output of the initialization step referenced Terraform v0.13. Upon investigation I found that the runner had Terraform v0.13 pre-installed (this was added in the [20200817 build](https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20200817.1) of the GH Actions virtual environments). This necessitated a change in the Terraform installation step of the same job to ensure our pinned version was being used.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing

GitHub Actions jobs successfully pass with caching still enabled. I also verified that we are using the pinned version of Terraform in our workflow now.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
