### PR TITLE
Remove terraform ecosystems for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,13 +11,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform-build-user"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "terraform"
-    directory: "/terraform-post-packer"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## 🗣 Description

This pull request reverts commit 0ac85436de5427b6463e0ea8fe05d8b92454cb72, removing the terraform ecosystem for dependabot.

## 💭 Motivation and Context

The terraform ecosystem is fairly broken, being unable to handle HCL2 and hence terraform versions 0.12 or greater.

See [this issue](https://github.com/dependabot/dependabot-core/pull/1388) for a more detailed explanation of the failures of the terraform ecosystem in dependabot.

Thanks to @mcdonnnj for chasing down the source of the dependabot build failures.

## 🧪 Testing

All pre-commit hooks and the dependabot checks pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
