### PR TITLE
Add missing Terraform install steps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,10 @@
 # Each line is a file pattern followed by one or more owners.
 
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# these owners will be requested for review when someone
-# opens a pull request.
+# These owners will be the default owners for everything in the
+# repo. Unless a later match takes precedence, these owners will be
+# requested for review when someone opens a pull request.
 * @dav3r @felddy @hillaryj @jsf9k @mcdonnnj
+
+# These folks own any files in the /.github directory at the root of
+# the repository and any of its subdirectories.
+/.github/ @dav3r @felddy @hillaryj @jsf9k @mcdonnnj

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 # requested for review when someone opens a pull request.
 * @dav3r @felddy @hillaryj @jsf9k @mcdonnnj
 
-# These folks own any files in the /.github directory at the root of
+# These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.
 /.github/ @dav3r @felddy @hillaryj @jsf9k @mcdonnnj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,26 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Store installed Python version
-        run: |
-          echo "PY_VERSION="\
-          "$(python -c "import platform;print(platform.python_version())")" \
-          >> $GITHUB_ENV
       - name: Cache linting environments
         uses: actions/cache@v2
         with:
           path: |
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.PRE_COMMIT_CACHE_DIR }}
-          key: "lint-${{ runner.os }}-py${{ env.PY_VERSION }}-\
+          key: |
+            lint-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}-\
             ${{ hashFiles('**/.pre-commit-config.yaml') }}"
           restore-keys: |
-            lint-${{ runner.os }}-py${{ env.PY_VERSION }}-
+            lint-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-
             lint-${{ runner.os }}-
       - name: Install dependencies
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -64,6 +64,8 @@ jobs:
           sudo unzip -d /opt/terraform \
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+          sudo mv /usr/local/bin/terraform /usr/local/bin/terraform-default
+          sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,8 @@ jobs:
           sudo unzip -d /opt/terraform \
             ${{ env.CURL_CACHE_DIR }}/"${TERRAFORM_ZIP}"
           sudo ln -s /opt/terraform/terraform /usr/bin/terraform
+          sudo mv /usr/local/bin/terraform /usr/local/bin/terraform-default
+          sudo ln -s /opt/terraform/terraform /usr/local/bin/terraform
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,30 +26,30 @@ repos:
           - --autofix
       - id: requirements-txt-fixer
       - id: trailing-whitespace
+
+  # Text file hooks
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.24.0
     hooks:
       - id: markdownlint
         args:
           - --config=.mdl_config.json
+  - repo: https://github.com/prettier/pre-commit
+    rev: v2.1.2
+    hooks:
+      - id: prettier
   - repo: https://github.com/adrienverge/yamllint
     rev: v1.25.0
     hooks:
       - id: yamllint
+
+  # Shell script hooks
   - repo: https://github.com/detailyang/pre-commit-shell
     rev: 1.0.5
     hooks:
       - id: shell-lint
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-docstrings
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
-    hooks:
-      - id: pyupgrade
+
+  # Python hooks
   - repo: https://github.com/PyCQA/bandit
     rev: 1.6.2
     hooks:
@@ -60,15 +60,33 @@ repos:
     rev: 20.8b1
     hooks:
       - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.4
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          - flake8-docstrings
   - repo: https://github.com/timothycrosley/isort
     rev: 5.6.4
     hooks:
       - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.790
+    hooks:
+      - id: mypy
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.7.2
+    hooks:
+      - id: pyupgrade
+
+  # Ansible hooks
   - repo: https://github.com/ansible/ansible-lint.git
     rev: v4.3.5
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
+
+  # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform.git
     rev: v1.43.0
     hooks:
@@ -89,15 +107,9 @@ repos:
       # above have been resolved, which we hope will be with the release of
       # Terraform 0.13.
       # - id: terraform_validate
+
+  # Docker hooks
   - repo: https://github.com/IamTheFij/docker-pre-commit
     rev: v2.0.0
     hooks:
       - id: docker-compose-check
-  - repo: https://github.com/prettier/pre-commit
-    rev: v2.1.2
-    hooks:
-      - id: prettier
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
-    hooks:
-      - id: mypy


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Terraform installation code in `prerelease.yml` and `release.yml` to add two additional steps that were present in `build.yml` but for some reason missing in the other two files.

Resolves #55.

## 💭 Motivation and Context ##

This old code was resulting in the system Terraform (currently 0.13) being used instead of the one we manually install (currently 0.12) in the `prerelease.yml` and `release.yml` workflows.

## 🧪 Testing ##

I made the same changes in cisagov/kali-packer@953f7bc2dc5ef79723f3b909f04dd916f9764496 and verified there that they resulted in the correct `terraform` executable being used.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
