### PR TITLE
Create a /usr/bin/python3 symlink to the installed python

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -79,12 +79,25 @@ jobs:
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_STAGING }}
           role-duration-seconds: 3600
+      # Ansible will find /usr/bin/python3 and use it, so we must
+      # ensure that it points to the version of python that we
+      # installed.  This can hose other tasks that are expecting to
+      # use the system python, though, so we undo this change after
+      # running packer.
+      - name: Create a /usr/bin/python3 symlink to the installed python
+        run: |
+          sudo mv /usr/bin/python3 /usr/bin/python3-default
+          sudo ln -s ${{ env.pythonLocation }}/bin/python3 \
+          /usr/bin/python3
       - name: Create machine image
         env:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
           GITHUB_RELEASE_URL: ${{ github.event.release.html_url }}
         run: packer build --timestamp-ui src/packer.json
+      - name: Remove /usr/bin/python3 symlink to the installed python
+        run: |
+          sudo mv /usr/bin/python3-default /usr/bin/python3
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v1
         if: env.RUN_TMATE

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -79,11 +79,12 @@ jobs:
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_STAGING }}
           role-duration-seconds: 3600
-      # Ansible will find /usr/bin/python3 and use it, so we must
-      # ensure that it points to the version of python that we
-      # installed.  This can hose other tasks that are expecting to
-      # use the system python, though, so we undo this change after
-      # running packer.
+      # When called by Packer, Ansible will find /usr/bin/python3 and
+      # use it; therefore, we must ensure that /usr/bin/python3 points
+      # to the version of python that we installed.  This can hose
+      # other tasks that are expecting to find the system python at
+      # that location, though, so we undo this change after running
+      # packer.
       - name: Create a /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3 /usr/bin/python3-default

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -81,10 +81,10 @@ jobs:
           role-duration-seconds: 3600
       # When called by Packer, Ansible will find /usr/bin/python3 and
       # use it; therefore, we must ensure that /usr/bin/python3 points
-      # to the version of python that we installed.  This can hose
-      # other tasks that are expecting to find the system python at
+      # to the version of Python that we installed.  This can hose
+      # other tasks that are expecting to find the system Python at
       # that location, though, so we undo this change after running
-      # packer.
+      # Packer.
       - name: Create a /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3 /usr/bin/python3-default

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -81,10 +81,10 @@ jobs:
           role-duration-seconds: 3600
       # When called by Packer, Ansible will find /usr/bin/python3 and
       # use it; therefore, we must ensure that /usr/bin/python3 points
-      # to the version of Python that we installed.  This can hose
-      # other tasks that are expecting to find the system Python at
-      # that location, though, so we undo this change after running
-      # Packer.
+      # to the version of Python that we installed in the
+      # actions/setup-python step above.  This can hose other tasks
+      # that are expecting to find the system Python at that location,
+      # though, so we undo this change after running Packer.
       - name: Create a /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3 /usr/bin/python3-default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,11 +94,12 @@ jobs:
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_PRODUCTION }}
           role-duration-seconds: 3600
-      # Ansible will find /usr/bin/python3 and use it, so we must
-      # ensure that it points to the version of python that we
-      # installed.  This can hose other tasks that are expecting to
-      # use the system python, though, so we undo this change after
-      # running packer.
+      # When called by Packer, Ansible will find /usr/bin/python3 and
+      # use it; therefore, we must ensure that /usr/bin/python3 points
+      # to the version of python that we installed.  This can hose
+      # other tasks that are expecting to find the system python at
+      # that location, though, so we undo this change after running
+      # packer.
       - name: Create a /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3 /usr/bin/python3-default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
           role-duration-seconds: 3600
       # When called by Packer, Ansible will find /usr/bin/python3 and
       # use it; therefore, we must ensure that /usr/bin/python3 points
-      # to the version of python that we installed.  This can hose
-      # other tasks that are expecting to find the system python at
+      # to the version of Python that we installed.  This can hose
+      # other tasks that are expecting to find the system Python at
       # that location, though, so we undo this change after running
-      # packer.
+      # Packer.
       - name: Create a /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3 /usr/bin/python3-default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,10 +96,10 @@ jobs:
           role-duration-seconds: 3600
       # When called by Packer, Ansible will find /usr/bin/python3 and
       # use it; therefore, we must ensure that /usr/bin/python3 points
-      # to the version of Python that we installed.  This can hose
-      # other tasks that are expecting to find the system Python at
-      # that location, though, so we undo this change after running
-      # Packer.
+      # to the version of Python that we installed in the
+      # actions/setup-python step above.  This can hose other tasks
+      # that are expecting to find the system Python at that location,
+      # though, so we undo this change after running Packer.
       - name: Create a /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3 /usr/bin/python3-default

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,12 +94,25 @@ jobs:
           aws-region: ${{ env.BUILD_REGION }}
           role-to-assume: ${{ secrets.BUILD_ROLE_TO_ASSUME_PRODUCTION }}
           role-duration-seconds: 3600
+      # Ansible will find /usr/bin/python3 and use it, so we must
+      # ensure that it points to the version of python that we
+      # installed.  This can hose other tasks that are expecting to
+      # use the system python, though, so we undo this change after
+      # running packer.
+      - name: Create a /usr/bin/python3 symlink to the installed python
+        run: |
+          sudo mv /usr/bin/python3 /usr/bin/python3-default
+          sudo ln -s ${{ env.pythonLocation }}/bin/python3 \
+          /usr/bin/python3
       - name: Create machine image
         env:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
           GITHUB_RELEASE_URL: ${{ github.event.release.html_url }}
         run: packer build --timestamp-ui src/packer.json
+      - name: Remove /usr/bin/python3 symlink to the installed python
+        run: |
+          sudo mv /usr/bin/python3-default /usr/bin/python3
       - name: Setup tmate debug session
         uses: mxschmitt/action-tmate@v1
         if: env.RUN_TMATE


### PR DESCRIPTION
## 🗣 Description ##

Resolves #56.

## 💭 Motivation and Context ##

When Ansible runs it will look for `/usr/bin/python3` and use it if it finds it; therefore, when Packer runs we need `/usr/bin/python3` to point to the python executable that we installed via the `setup-python` action.

This change will hose other tasks that expect to find the system python at `/usr/bin/python3`, though, so we undo the change after running Packer.

## 🧪 Testing ##

I made the same changes in cisagov/kali-packer@b3a5c6fc653d843827d5dcdb30ca1165debe48e7 and verified there that they resulted in the correct `python3` executable being used.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
