### PR TITLE
Fix several places where I neglected to remove references to PY_VERSION env var

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,14 +112,10 @@ jobs:
     steps:
       - uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Store installed Python version
-        run: |
-          echo "PY_VERSION="\
-          "$(python -c "import platform;print(platform.python_version())")" \
-          >> $GITHUB_ENV
       - name: Cache testing environments
         uses: actions/cache@v2
         with:
@@ -127,12 +123,13 @@ jobs:
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
           key: "test-${{ runner.os }}-\
-            py${{ env.PY_VERSION }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             packer${{ env.PACKER_VERSION }}-\
             ${{ hashFiles('**/requirements-test.txt') }}-\
             ${{ hashFiles('**/requirements.txt') }}"
           restore-keys: |
-            test-${{ runner.os }}-py${{ env.PY_VERSION }}-\
+            test-${{ runner.os }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             packer${{ env.PACKER_VERSION }}-
             test-${{ runner.os }}-
       - name: Install Packer

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -19,14 +19,10 @@ jobs:
     steps:
       - uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Store installed Python version
-        run: |
-          echo "PY_VERSION="\
-          "$(python -c "import platform;print(platform.python_version())")" \
-          >> $GITHUB_ENV
       - name: Cache prerelease building environments
         uses: actions/cache@v2
         with:
@@ -34,13 +30,13 @@ jobs:
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
           key: "prerelease-${{ runner.os }}-\
-            py${{ env.PY_VERSION }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             packer-${{ env.PACKER_VERSION }}-\
             tf-${{ env.TERRAFORM_VERSION }}-\
             ${{ hashFiles('**/requirements.txt') }}"
           restore-keys: |
             prerelease-${{ runner.os }}-\
-            py${{ env.PY_VERSION }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             packer-${{ env.PACKER_VERSION }}-\
             tf-${{ env.TERRAFORM_VERSION }}-
             prerelease-${{ runner.os }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,10 @@ jobs:
     steps:
       - uses: cisagov/setup-env-github-action@develop
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - id: setup-python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Store installed Python version
-        run: |
-          echo "PY_VERSION="\
-          "$(python -c "import platform;print(platform.python_version())")" \
-          >> $GITHUB_ENV
       - name: Cache release building environments
         uses: actions/cache@v2
         with:
@@ -41,13 +37,13 @@ jobs:
             ${{ env.PIP_CACHE_DIR }}
             ${{ env.CURL_CACHE_DIR }}
           key: "release-${{ runner.os }}-\
-            py${{ env.PY_VERSION }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             packer-${{ env.PACKER_VERSION }}-\
             tf-${{ env.TERRAFORM_VERSION }}-\
             ${{ hashFiles('**/requirements.txt') }}"
           restore-keys: |
             release-${{ runner.os }}-\
-            py${{ env.PY_VERSION }}-\
+            py${{ steps.setup-python.outputs.python-version }}-\
             packer-${{ env.PACKER_VERSION }}-\
             tf-${{ env.TERRAFORM_VERSION }}-
             release-${{ runner.os }}-


### PR DESCRIPTION
## 🗣 Description ##

In this pull request I fix several places in the GitHub Actions workflows where I neglected to remove references to the `PY_VERSION` environment variable.

## 💭 Motivation and Context ##

This should have been done as part of merging in the latest lineage pull request.

## 🧪 Testing ##

All GitHub Actions pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
