### PR TITLE
Revert to Unmodified pre-commit Configuration in GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,23 +90,8 @@ jobs:
           pip install --upgrade --requirement requirements-test.txt
       - name: Set up pre-commit hook environments
         run: pre-commit install-hooks
-      - name: Create modified GitHub Actions pre-commit configuration
-        run: |
-          sed '/terraform_validate/d' < .pre-commit-config.yaml \
-          > /tmp/.github-actions-pre-commit-config.yaml
-      - name: Run pre-commit with modified configuration file on all files
-        # We run pre-commit here with a custom configuration that has
-        # the terraform-validate hook removed.  This is because
-        # terraform validate cannot currently run without accessing
-        # the remote state because of the way the providers are
-        # defined in providers.tf.  This is something that may be
-        # remedied in the future.  For more information, check out
-        # these two GitHub issues:
-        # * https://github.com/hashicorp/terraform/issues/15895
-        # * https://github.com/hashicorp/terraform/issues/15811
-        run: |
-          pre-commit run --all-files \
-          --config=/tmp/.github-actions-pre-commit-config.yaml
+      - name: Run pre-commit on all files
+        run: pre-commit run --all-files
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR removes the customized `pre-commit` configuration that was added because of issues we were having with the `terraform_validate` hook.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and Context ##

This customization is no longer required because the offending hook is disabled per https://github.com/cisagov/skeleton-packer/blob/a07d31cae87032a0aa5ab43263c812c56028ac09/.pre-commit-config.yaml#L103-L118
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

The Actions workflow completes successfully as expected.
<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
