### PR TITLE
Use FQCNs

### DIFF
--- a/src/playbook.yml
+++ b/src/playbook.yml
@@ -1,9 +1,9 @@
 ---
 - name: Import base image playbook
-  import_playbook: base.yml
+  ansible.builtin.import_playbook: base.yml
 
 - name: Import AWS playbook
-  import_playbook: aws.yml
+  ansible.builtin.import_playbook: aws.yml
 
 - name: Import Example playbook
-  import_playbook: example.yml
+  ansible.builtin.import_playbook: example.yml


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible code to use fully qualified collection names (FQCNs) for all Ansible modules.

## 💭 Motivation and context ##

FQCNs are the future of Ansible.

## 🧪 Testing ##

All `pre-commit` hooks pass.  I have also successfully built AMIs using these same changes in cisagov/teamserver-packer#27 and cisagov/kali-packer#61, and cisagov/nessus-packer#25.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
