### PR TITLE
Use provider default_tags instead of manually passing tags to modules

### DIFF
--- a/terraform-build-user/main.tf
+++ b/terraform-build-user/main.tf
@@ -11,8 +11,4 @@ module "iam_user" {
 
   ssm_parameters = ["/cyhy/dev/users", "/ssh/public_keys/*"]
   user_name      = "build-skeleton-packer"
-  tags = {
-    Team        = "CISA - Development"
-    Application = "skeleton-packer"
-  }
 }

--- a/terraform-build-user/providers.tf
+++ b/terraform-build-user/providers.tf
@@ -7,6 +7,11 @@ locals {
   # https://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html
   # for information about acceptable characters for the session name.
   caller_user_name = replace(data.aws_caller_identity.terraform_backend.user_id, ":", ".")
+
+  tags = {
+    Team        = "CISA - Development"
+    Application = "skeleton-packer"
+  }
 }
 
 # Provider that is only used for obtaining the caller identity.
@@ -18,56 +23,74 @@ locals {
 # Hence, for our caller identity, we use a provider based on a profile that
 # must exist for the Terraform backend to work ("cool-terraform-backend").
 provider "aws" {
-  alias   = "cool-terraform-backend"
-  region  = "us-east-1"
+  alias = "cool-terraform-backend"
+  default-tags {
+    tags = local.tags
+  }
   profile = "cool-terraform-backend"
+  region  = "us-east-1"
 }
 
 # Default AWS provider (ProvisionAccount for the Users account)
 provider "aws" {
-  region = "us-east-1"
   assume_role {
     role_arn     = data.terraform_remote_state.users.outputs.provisionaccount_role.arn
     session_name = local.caller_user_name
   }
+  default-tags {
+    tags = local.tags
+  }
+  region = "us-east-1"
 }
 
 # ProvisionEC2AMICreateRoles AWS provider for the Images Production account
 provider "aws" {
-  alias  = "images-production-ami"
-  region = "us-east-1"
+  alias = "images-production-ami"
   assume_role {
     role_arn     = data.terraform_remote_state.images_production.outputs.provisionec2amicreateroles_role.arn
     session_name = local.caller_user_name
   }
+  default-tags {
+    tags = local.tags
+  }
+  region = "us-east-1"
 }
 
 # ProvisionParameterStoreReadRoles AWS provider for the Images Production account
 provider "aws" {
-  alias  = "images-production-ssm"
-  region = "us-east-1"
+  alias = "images-production-ssm"
   assume_role {
     role_arn     = data.terraform_remote_state.images_parameterstore_production.outputs.provisionparameterstorereadroles_role.arn
     session_name = local.caller_user_name
   }
+  default-tags {
+    tags = local.tags
+  }
+  region = "us-east-1"
 }
 
 # ProvisionEC2AMICreateRoles AWS provider for the Images Staging account
 provider "aws" {
-  alias  = "images-staging-ami"
-  region = "us-east-1"
+  alias = "images-staging-ami"
   assume_role {
     role_arn     = data.terraform_remote_state.images_staging.outputs.provisionec2amicreateroles_role.arn
     session_name = local.caller_user_name
   }
+  default-tags {
+    tags = local.tags
+  }
+  region = "us-east-1"
 }
 
 # ProvisionParameterStoreReadRoles AWS provider for the Images Staging account
 provider "aws" {
-  alias  = "images-staging-ssm"
-  region = "us-east-1"
+  alias = "images-staging-ssm"
   assume_role {
     role_arn     = data.terraform_remote_state.images_parameterstore_staging.outputs.provisionparameterstorereadroles_role.arn
     session_name = local.caller_user_name
   }
+  default-tags {
+    tags = local.tags
+  }
+  region = "us-east-1"
 }

--- a/terraform-post-packer/providers.tf
+++ b/terraform-post-packer/providers.tf
@@ -1,12 +1,25 @@
+locals {
+  tags = {
+    Team        = "CISA - Development"
+    Application = "skeleton-packer"
+  }
+}
+
 # Default AWS provider (EC2AMICreate role in the Images account)
 provider "aws" {
-  region  = "us-east-1"
+  default-tags {
+    tags = local.tags
+  }
   profile = "cool-images-ec2amicreate"
+  region  = "us-east-1"
 }
 
 # AWS provider for the Master account (OrganizationsReadOnly role)
 provider "aws" {
-  region  = "us-east-1"
+  alias = "master"
+  default-tags {
+    tags = local.tags
+  }
   profile = "cool-master-organizationsreadonly"
-  alias   = "master"
+  region  = "us-east-1"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
* Alphabetizes the keys inside `provider` blocks
* Adds a `default_tags` key to each `provider` block
* Modifies code to use the provider's `default_tags` instead of passing tags explicitly to modules

## 💭 Motivation and context ##

Once cisagov/ami-build-iam-user-tf-module#27 is merged, passing `tags` to the module will at best not function as intended and at worst will be an error.

## 🧪 Testing ##

All `pre-commit` hooks pass.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
