### PR TITLE
Require AWS provider version to support default tags

### DIFF
--- a/terraform-build-user/versions.tf
+++ b/terraform-build-user/versions.tf
@@ -6,6 +6,9 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 3.0"
+    # Version 3.38.0 of the Terraform AWS provider is the first
+    # version to support default tags.
+    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    aws = "~> 3.38"
   }
 }

--- a/terraform-build-user/versions.tf
+++ b/terraform-build-user/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  # We want to hold off on 0.13 until we have tested it.
+  # We want to hold off on 0.13 or higher until we have tested it.
   required_version = "~> 0.12.0"
 
   # If you use any other providers you should also pin them to the

--- a/terraform-post-packer/versions.tf
+++ b/terraform-post-packer/versions.tf
@@ -6,6 +6,9 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    aws = "~> 3.0"
+    # Version 3.38.0 of the Terraform AWS provider is the first
+    # version to support default tags.
+    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    aws = "~> 3.38"
   }
 }

--- a/terraform-post-packer/versions.tf
+++ b/terraform-post-packer/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  # We want to hold off on 0.13 until we have tested it.
+  # We want to hold off on 0.13 or higher until we have tested it.
   required_version = "~> 0.12.0"
 
   # If you use any other providers you should also pin them to the


### PR DESCRIPTION


# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR sets the minimum version of the Terraform AWS provider to version 3.38.0.  That is the first version to support [default tags](https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider).

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This was overlooked earlier and it must be corrected.  These changes are identical to those in https://github.com/cisagov/skeleton-tf-module/commit/7471af2a3e56f42d5c818432a7f1eb5ded2f709c.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully ran a `terraform init --upgrade` in both Terraform subdirectories of this project and no errors were observed.

<!-- How did you test your changes? How could someone else test this PR? -->

<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
