### PR TITLE
Add NTP client configured for AWS

### DIFF
--- a/src/aws.yml
+++ b/src/aws.yml
@@ -7,6 +7,7 @@
     - amazon_ssm_agent
     # This is for the python3-botocore task below
     - backports
+    - chrony_aws
     - cloudwatch_agent
     # The instance types used for almost all the instances expose EBS
     # volumes as NVMe block devices, so that's why we need nvme here.

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -7,6 +7,8 @@
   name: backports
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
+- src: https://github.com/cisagov/ansible-role-chrony-aws
+  name: chrony_aws
 - src: https://github.com/cisagov/ansible-role-clamav
   name: clamav
 - src: https://github.com/cisagov/ansible-role-cloudwatch-agent


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the [`chrony`](https://chrony.tuxfamily.org/) NTP client and configures it for AWS.

## 💭 Motivation and context ##

This addition is necessary to keep every machine's clock in sync, which is in turn critical when comparing logs from different machines.  This addition was made manually for some descendants of this repository but not others, but I think it makes sense to include in all AMIs.

## 🧪 Testing ##

All `pre-commit` hooks pass and these changes are already present in, for example, [cisagov/teamserver-packer](https://github.com/cisagov/teamserver-packer).

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
