### PR TITLE
Upgrade to Debian Bullseye (AKA Debian 11)

### DIFF
--- a/src/packer.json
+++ b/src/packer.json
@@ -30,7 +30,7 @@
       "skip_create_ami": "{{user `skip_create_ami`}}",
       "source_ami_filter": {
         "filters": {
-          "name": "debian-10-amd64-*",
+          "name": "debian-11-amd64-*",
           "root-device-type": "ebs",
           "virtualization-type": "hvm"
         },
@@ -49,7 +49,7 @@
         "Application": "Example",
         "Base_AMI_Name": "{{ .SourceAMIName }}",
         "GitHub_Release_URL": "{{user `github_release_url`}}",
-        "OS_Version": "Debian Buster",
+        "OS_Version": "Debian Bullseye",
         "Pre_Release": "{{user `github_is_prerelease`}}",
         "Release": "{{user `github_release_tag`}}",
         "Team": "VM Fusion - Development"


### PR DESCRIPTION
## 🗣 Description ##

This pull request upgrades the `packer` configuration to use a Debian Bullseye base image.  Previously it was using a Debian Buster base image.

I also took the liberty of subscribing both our staging and production COOL Images accounts to the official Debian 11 AMI, which is the base AMI referenced in this repo's `packer` configuration.

## 💭 Motivation and context ##

Debian Bullseye has been out for almost a month, and the Debian Buster packages are getting pretty long in the tooth, so it makes sense to upgrade all our AMIs.

This will also encourage us to check it there is an updated base AMI for each of our AMIs that are built on something other than Debian.

Once these changes are propagated down, they will resolve cisagov/assessor-portal-packer#2 and also resolve cisagov/pca-gophish-composition-packer#56.

## 🧪 Testing ##

All `pre-commit` hooks and GH Actions checks pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
