### PR TITLE
Add ability to specify extraorg accounts that can launch the AMI

### DIFF
--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -49,13 +49,14 @@ data "aws_ami" "example" {
 
 # Assign launch permissions to the AMI
 module "ami_launch_permission" {
-  source = "github.com/cisagov/ami-launch-permission-tf-module"
+  source = "github.com/cisagov/ami-launch-permission-tf-module?ref=improvement%2Fadd-ability-to-add-launch-permission-by-account-id"
 
   providers = {
     aws        = aws
     aws.master = aws.master
   }
 
-  account_name_regex = local.account_name_regex
-  ami_id             = data.aws_ami.example.id
+  account_name_regex   = local.account_name_regex
+  ami_id               = data.aws_ami.example.id
+  extraorg_account_ids = var.extraorg_account_ids
 }

--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -49,7 +49,7 @@ data "aws_ami" "example" {
 
 # Assign launch permissions to the AMI
 module "ami_launch_permission" {
-  source = "github.com/cisagov/ami-launch-permission-tf-module?ref=improvement%2Fadd-ability-to-add-launch-permission-by-account-id"
+  source = "github.com/cisagov/ami-launch-permission-tf-module"
 
   providers = {
     aws        = aws

--- a/terraform-post-packer/outputs.tf
+++ b/terraform-post-packer/outputs.tf
@@ -1,4 +1,4 @@
 output "accounts" {
   value       = module.ami_launch_permission.accounts
-  description = "A map whose keys are the account names allowed to launch the AMI and whose values are the account IDs and the AMI ID."
+  description = "A map whose keys are the IDs of the AWS accounts allowed to launch the AMI, and whose values are the aws_ami_launch_permission resources for the corresponding launch permissions."
 }

--- a/terraform-post-packer/variables.tf
+++ b/terraform-post-packer/variables.tf
@@ -1,0 +1,11 @@
+# ------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+#
+# These parameters have reasonable defaults.
+# ------------------------------------------------------------------------------
+
+variable "extraorg_account_ids" {
+  type        = list(string)
+  description = "A list of AWS account IDs corresponding to \"extra\" accounts with which you want to share this AMI (e.g. [\"123456789012\"]).  Normally this variable is used to share an AMI with accounts that are not a member of the same AWS Organization as the account that owns the AMI."
+  default     = []
+}


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the ability to specify a list of extra-organizational AWS account IDs that can launch the AMI.

## 💭 Motivation and context ##

I require this change in order to allow the CEIL SharedServices account to use our OpenVPN and FreeIPA AMIs.

## 🧪 Testing ##

All GitHub Actions checks pass.

## ✅ Pre-review checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Revert to the default branch of [cisagov/ami-launch-permission-tf-module](https://github.com/cisagov/ami-launch-permission-tf-module/pull/20) once cisagov/ami-launch-permission-tf-module#20 is merged.