### PR TITLE
Remove extra dash on Packer CLI flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,7 +236,7 @@ jobs:
         # This runs through the AMI creation process but does not
         # actually create an AMI
         run: |
-          packer build --timestamp-ui -var skip_create_ami=true \
+          packer build -timestamp-ui -var skip_create_ami=true \
           src/packer.json
       - name: Remove /usr/bin/python3 symlink to the installed Python
         run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -87,7 +87,7 @@ jobs:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
           GITHUB_RELEASE_URL: ${{ github.event.release.html_url }}
-        run: packer build --timestamp-ui src/packer.json
+        run: packer build -timestamp-ui src/packer.json
       - name: Remove /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3-default /usr/bin/python3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           GITHUB_IS_PRERELEASE: ${{ github.event.release.prerelease }}
           GITHUB_RELEASE_TAG: ${{ github.event.release.tag_name }}
           GITHUB_RELEASE_URL: ${{ github.event.release.html_url }}
-        run: packer build --timestamp-ui src/packer.json
+        run: packer build -timestamp-ui src/packer.json
       - name: Remove /usr/bin/python3 symlink to the installed python
         run: |
           sudo mv /usr/bin/python3-default /usr/bin/python3


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes an extra dash on the `timestamp-ui` flag for the Packer CLI.

## 💭 Motivation and context ##

Hashicorp tools prefer single dashes, even for the long version of flags.

## 🧪 Testing ##

All GitHub Actions checks pass.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
