### PR TITLE
Upgrade the root volume type to gp3

### DIFF
--- a/src/packer.json
+++ b/src/packer.json
@@ -7,7 +7,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "ami_name": "example-hvm-{{timestamp}}-x86_64-ebs",
@@ -22,7 +22,7 @@
           "device_name": "/dev/xvda",
           "encrypted": true,
           "volume_size": 8,
-          "volume_type": "gp2"
+          "volume_type": "gp3"
         }
       ],
       "region": "{{user `build_region`}}",


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Packer configuration to use gp3 volumes.

## 💭 Motivation and context ##

gp3 is 20% cheaper, and the baseline configuration offers better performance than gp2 for volumes smaller than 2TB.  It also allows the volume size and IOPS to be configured separately, whereas the two are intertwined with gp2.

## 🧪 Testing ##

All GitHub Actions checks complete successfully.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
