### PR TITLE
Grant launch permission for multiple recent AMIs

### DIFF
--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -50,7 +50,7 @@ data "aws_ami_ids" "historical_amis" {
 module "ami_launch_permission" {
   # Really we only want the var.recent_ami_count most recent AMIs, but
   # we have to cover the case where there are fewer than that many
-  # AMIs in existence.  Hence the max()/length() tomfoolery.
+  # AMIs in existence.  Hence the min()/length() tomfoolery.
   for_each = toset(slice(data.aws_ami_ids.historical_amis.ids, 0, min(var.recent_ami_count, length(data.aws_ami_ids.historical_amis.ids))))
 
   source = "github.com/cisagov/ami-launch-permission-tf-module"

--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -24,8 +24,8 @@ locals {
   account_name_regex  = format("^env[[:digit:]]+ \\(%s\\)$", local.images_account_type)
 }
 
-# The most-recent AMI created by cisagov/skeleton-packer
-data "aws_ami" "example" {
+# The IDs of all cisagov/skeleton-packer AMIs
+data "aws_ami_ids" "historical_amis" {
   filter {
     name = "name"
     values = [
@@ -43,12 +43,16 @@ data "aws_ami" "example" {
     values = ["ebs"]
   }
 
-  owners      = [data.aws_caller_identity.images.account_id]
-  most_recent = true
+  owners = [data.aws_caller_identity.images.account_id]
 }
 
 # Assign launch permissions to the AMI
 module "ami_launch_permission" {
+  # Really we only want the var.recent_ami_count most recent AMIs, but
+  # we have to cover the case where there are fewer than that many
+  # AMIs in existence.  Hence the max()/length() tomfoolery.
+  for_each = toset(slice(data.aws_ami_ids.historical_amis.ids, 0, min(var.recent_ami_count, length(data.aws_ami_ids.historical_amis.ids))))
+
   source = "github.com/cisagov/ami-launch-permission-tf-module"
 
   providers = {
@@ -57,6 +61,6 @@ module "ami_launch_permission" {
   }
 
   account_name_regex   = local.account_name_regex
-  ami_id               = data.aws_ami.example.id
+  ami_id               = each.value
   extraorg_account_ids = var.extraorg_account_ids
 }

--- a/terraform-post-packer/outputs.tf
+++ b/terraform-post-packer/outputs.tf
@@ -1,4 +1,4 @@
-output "accounts" {
-  value       = module.ami_launch_permission.accounts
-  description = "A map whose keys are the IDs of the AWS accounts allowed to launch the AMI, and whose values are the aws_ami_launch_permission resources for the corresponding launch permissions."
+output "launch_permissions" {
+  value       = module.ami_launch_permission
+  description = "The cisagov/ami-launch-permission-tf-module for each AMI to which launch permission is being granted."
 }

--- a/terraform-post-packer/variables.tf
+++ b/terraform-post-packer/variables.tf
@@ -9,3 +9,9 @@ variable "extraorg_account_ids" {
   description = "A list of AWS account IDs corresponding to \"extra\" accounts with which you want to share this AMI (e.g. [\"123456789012\"]).  Normally this variable is used to share an AMI with accounts that are not a member of the same AWS Organization as the account that owns the AMI."
   default     = []
 }
+
+variable "recent_ami_count" {
+  type        = number
+  description = "The number of most-recent AMIs for which to grant launch permission (e.g. \"3\").  If this variable is set to three, for example, then accounts will be granted permission to launch the three most recent AMIs."
+  default     = 12
+}

--- a/terraform-post-packer/variables.tf
+++ b/terraform-post-packer/variables.tf
@@ -12,6 +12,6 @@ variable "extraorg_account_ids" {
 
 variable "recent_ami_count" {
   type        = number
-  description = "The number of most-recent AMIs for which to grant launch permission (e.g. \"3\").  If this variable is set to three, for example, then accounts will be granted permission to launch the three most recent AMIs."
+  description = "The number of most-recent AMIs for which to grant launch permission (e.g. \"3\").  If this variable is set to three, for example, then accounts will be granted permission to launch the three most recent AMIs (or all most recent AMIs, if there are only one or two of them in existence)."
   default     = 12
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the post-Packer code to grant launch permission for several of the most recent AMIs.  Previously launch permission was granted only for _the_ most recent AMI.

This entails:
* Adding an input variable to specify X, the number of most-recent AMIs.
* Modifying `main.tf` to grant launch permission for the X most recent AMIs.
* Modifying the output to return the resulting array of [cisagov/ami-launch-permission-tf-module](https://github.com/cisagov/ami-launch-permission-tf-module) objects.

## 💭 Motivation and context ##

This is a necessary change because assessments can go on for several months, and [cisagov/guacscanner](https://github.com/cisagov/guacscanner) needs to be able to view AMI information in order to create Guacamole connections.  If Guacamole is re-deployed mid-assessment, then [cisagov/guacscanner](https://github.com/cisagov/guacscanner) may need to re-create connections for old AMIs.

It is important to grant full launch permissions for these historical AMIs, since some assessment types will want to launch additional instances using the same AMI from which their original instances were launched.

Resolves cisagov/cool-system-internal#47.

## 🧪 Testing ##

I applied the new code to the staging Terraform workspace and verified that it created the expected resources.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
