### PR TITLE
Improvement/use ed25519 temporary key pair

### DIFF
--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -100,7 +100,7 @@ source "amazon-ebs" "example" {
     Team               = "VM Fusion - Development"
   }
   # Many Linux distributions are now disallowing the use of RSA keys,
-  # so it makes sense to use anED25519 key instead.
+  # so it makes sense to use an ED25519 key instead.
   temporary_key_pair_type = "ed25519"
   vpc_filter {
     filters = {

--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -99,6 +99,9 @@ source "amazon-ebs" "example" {
     Release            = var.release_tag
     Team               = "VM Fusion - Development"
   }
+  # Many Linux distributions are now disallowing the use of RSA keys,
+  # so it makes sense to use anED25519 key instead.
+  temporary_key_pair_type = "ed25519"
   vpc_filter {
     filters = {
       "tag:Name" = "AMI Build"


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `packer` configuration to use an ED25519 temporary key pair instead of the default RSA key pair.

__Please note that #98 must be merged before this pull request.  This branch must also be rebased after merging #98.__

## 💭 Motivation and context ##

Linux distributions are starting to disallow the use of RSA keys by default, so it makes sense to use an ED25519 key instead.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.