### PR TITLE
Add Dependabot ignore directives for `hashicorp/aws`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,10 @@
 ---
 
+# Any ignore directives should be uncommented in downstream projects to disable
+# Dependabot updates for the given dependency. Downstream projects will get
+# these updates when the pull request(s) in the appropriate skeleton are merged
+# and Lineage processes these changes.
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,12 @@ updates:
     directory: "/terraform-build-user"
     schedule:
       interval: "weekly"
+    # ignore:
+    #   - dependency-name: "hashicorp/aws"
 
   - package-ecosystem: "terraform"
     directory: "/terraform-post-packer"
     schedule:
       interval: "weekly"
+    # ignore:
+    #   - dependency-name: "hashicorp/aws"

--- a/.mdl_config.yaml
+++ b/.mdl_config.yaml
@@ -48,3 +48,13 @@ MD035:
 MD046:
   # Enforce the fenced style for code blocks
   style: "fenced"
+
+# MD049/emphasis-style - Emphasis style should be consistent
+MD049:
+  # Enforce asterisks as the style to use for emphasis
+  style: "asterisk"
+
+# MD050/strong-style - Strong style should be consistent
+MD050:
+  # Enforce asterisks as the style to use for strong
+  style: "asterisk"

--- a/.mdl_config.yaml
+++ b/.mdl_config.yaml
@@ -44,7 +44,7 @@ MD035:
   # Enforce dashes for horizontal rules
   style: "---"
 
-# MD046/code-block-style Code block style
+# MD046/code-block-style - Code block style
 MD046:
   # Enforce the fenced style for code blocks
   style: "fenced"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
 
   # Text file hooks
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.30.0
+    rev: v0.31.1
     hooks:
       - id: markdownlint
         args:
@@ -49,7 +49,7 @@ repos:
 
   # pre-commit hooks
   - repo: https://github.com/pre-commit/pre-commit
-    rev: v2.16.0
+    rev: v2.17.0
     hooks:
       - id: validate_manifest
 
@@ -75,13 +75,13 @@ repos:
 
   # Python hooks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.1
+    rev: 1.7.2
     hooks:
       - id: bandit
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8
@@ -105,14 +105,14 @@ repos:
 
   # Ansible hooks
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v5.3.2
+    rev: v5.4.0
     hooks:
       - id: ansible-lint
       # files: molecule/default/playbook.yml
 
   # Terraform hooks
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.62.3
+    rev: v1.64.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/.yamllint
+++ b/.yamllint
@@ -2,6 +2,12 @@
 extends: default
 
 rules:
+  # yamllint does not like it when you comment out different parts of
+  # dictionaries in a list. You can see
+  # https://github.com/adrienverge/yamllint/issues/384 for some examples of
+  # this behavior.
+  comments-indentation: disable
+
   # yamllint doesn't like when we use yes and no for true and false,
   # but that's pretty standard in Ansible.
   truthy: disable

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ how the build was triggered from GitHub.
 
 1. **Non-release test**: After a normal commit or pull request GitHub Actions
    will build the project, and run tests and validation on the
-   packer configuration. It will __not__ build an image.
+   packer configuration. It will **not** build an image.
 1. **Pre-release deploy**: Publish a GitHub release
    with the "This is a pre-release" checkbox checked. An image will be built
    and deployed using the [`prerelease`](.github/workflows/prerelease.yml)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates the Dependabot configurations for `terraform-build-user/` and `terraform-post-packer/` to include commented out ignore directives for the `hashicorp/aws` provider. This pull request relies on #104 being merged.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

These commented out ignore blocks should be uncommented downstream to ensure that updates to the `hashicorp/aws` provider are only automatically generated by Dependabot in this repository. Any updates will then be pushed downstream using our Lineage process.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
