### PR TITLE
Force the Ansible provisioner to use sftp instead of scp

### DIFF
--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -114,15 +114,18 @@ build {
 
   provisioner "ansible" {
     playbook_file = "src/upgrade.yml"
+    use_sftp      = true
   }
 
   provisioner "ansible" {
     playbook_file = "src/python.yml"
+    use_sftp      = true
   }
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     playbook_file    = "src/playbook.yml"
+    use_sftp         = true
   }
 
   provisioner "shell" {


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Packer configuration to force the Ansible provisioner to use `sftp` rather than `ssh`.

## 💭 Motivation and context ##

The latest Kali base AMI has an OpenSSH version greater than or equal to 9.0 installed.  `scp` fails in that case [because of a breaking change](https://www.openssh.com/txt/release-9.0).

This will be a problem for our other AMIs as other base AMIs upgrade to newer versions of OpenSSH.

The use of `sftp` is the default behavior for Ansible, but Packer's Ansible provisioner forces the use of `scp` by default as of hashicorp/packer@f760ab2.

## 🧪 Testing ##

The automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.