### PR TITLE
Remove dev SSH keys from AMIs

### DIFF
--- a/src/base.yml
+++ b/src/base.yml
@@ -7,6 +7,5 @@
     - automated_security_updates
     - banner
     - clamav
-    - dev_ssh_access
     - htop
     - persist_journald

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -15,8 +15,6 @@
   name: clamav
 - src: https://github.com/cisagov/ansible-role-cloudwatch-agent
   name: cloudwatch_agent
-- src: https://github.com/cisagov/ansible-role-dev-ssh-access
-  name: dev_ssh_access
 - src: https://github.com/cisagov/skeleton-ansible-role
   name: example
 - src: https://github.com/cisagov/ansible-role-htop


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes from the skeleton the Ansible role that adds the dev team's `ssh` keys to the AMI.

## 💭 Motivation and context ##

These keys are no longer required (or desired) now that we are using AWS Session Manager directly.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.