### PR TITLE
Remove Debian Buster-specific configuration elements

### DIFF
--- a/src/aws.yml
+++ b/src/aws.yml
@@ -6,24 +6,8 @@
   roles:
     - amazon_efs_utils
     - amazon_ssm_agent
-    # This is for the python3-botocore task below
-    - backports
     - chrony_aws
     - cloudwatch_agent
     # The instance types used for almost all the instances expose EBS
     # volumes as NVMe block devices, so that's why we need nvme here.
     - nvme
-  tasks:
-    # The version of python3-botocore in Debian Buster is too old to
-    # support IMDSv2.  I was able to get a more recent version
-    # published to buster-backports that does support IMDSv2, so we
-    # should use that.
-    - name: Install python3-botocore from buster-backports for Debian Buster
-      ansible.builtin.apt:
-        default_release: buster-backports
-        name:
-          - python3-botocore
-        state: latest
-      when:
-        - ansible_distribution == "Debian"
-        - ansible_distribution_release == "buster"

--- a/src/requirements.yml
+++ b/src/requirements.yml
@@ -5,8 +5,6 @@
   name: amazon_ssm_agent
 - src: https://github.com/cisagov/ansible-role-automated-security-updates
   name: automated_security_updates
-- src: https://github.com/cisagov/ansible-role-backports
-  name: backports
 - src: https://github.com/cisagov/ansible-role-banner
   name: banner
 - src: https://github.com/cisagov/ansible-role-chrony-aws


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request removes [cisagov/ansible-role-backports](https://github.com/cisagov/ansible-role-backports) from the requirements as well as removing the Packer configuration that uses it to install a package.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Previously we needed these pieces to install an IDMSv2 supporting version of the [botocore](https://github.com/boto/botocore) package. These pieces were missed in https://github.com/cisagov/skeleton-packer/pull/83 when we upgraded to Debian Bullseye.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
