### PR TITLE
Set use_proxy to false for Ansible provisioners

### DIFF
--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -114,17 +114,20 @@ build {
 
   provisioner "ansible" {
     playbook_file = "src/upgrade.yml"
+    use_proxy     = false
     use_sftp      = true
   }
 
   provisioner "ansible" {
     playbook_file = "src/python.yml"
+    use_proxy     = false
     use_sftp      = true
   }
 
   provisioner "ansible" {
     ansible_env_vars = ["AWS_DEFAULT_REGION=${var.build_region}"]
     playbook_file    = "src/playbook.yml"
+    use_proxy        = false
     use_sftp         = true
   }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request sets `use_proxy` to `false` for all Ansible provisioners.

## 💭 Motivation and context ##

This fixes our Packer builds that descend from [cisagov/skeleton-packer](https://github.com/cisagov/skeleton-packer), which have all been failing since November 23 when Ubuntu 22.04 became the default OS for GitHub Actions' runners.  See, for example, [this failing build](https://github.com/cisagov/samba-packer/actions/runs/3534584325) and [this successful build](https://github.com/cisagov/samba-packer/actions/runs/3541656743).  The only differences between the two builds are the changes in this pull request.

The issue is that the proxy uses an RSA key, which the newer version of OpenSSL in GitHub Actions' Ubuntu 22.04 runner host now rejects as insecure. Note that this same change was already made in cisagov/cyhy_amis#441.

It is also worth noting that `use_proxy = false` is the default setting for Ansible; Packer explicitly overrides this default.

## 🧪 Testing ##

All automated tests now pass.  This is not the case without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.