### PR TITLE
Remove unnecessary ami_block_device_mappings block

### DIFF
--- a/src/packer.pkr.hcl
+++ b/src/packer.pkr.hcl
@@ -60,13 +60,6 @@ data "amazon-ami" "debian_bullseye" {
 locals { timestamp = regex_replace(timestamp(), "[- TZ:]", "") }
 
 source "amazon-ebs" "example" {
-  ami_block_device_mappings {
-    delete_on_termination = true
-    device_name           = "/dev/xvda"
-    encrypted             = true
-    volume_size           = 8
-    volume_type           = "gp3"
-  }
   ami_name                    = "example-hvm-${local.timestamp}-x86_64-ebs"
   ami_regions                 = var.ami_regions
   associate_public_ip_address = true


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes an unnecessary `ami_block_device_mappings` block.

## 💭 Motivation and context ##

One only needs to specify `ami_block_mappings_block` to [add _additional_ volumes when the AMI launches that are not present when the instance on which the AMI is built is launched](https://developer.hashicorp.com/packer/plugins/builders/amazon/ebs#ami-block-device-mappings-example).  I suppose another use might be if you want the root disk when the AMI is launched to be different than it is when the instance on which the AMI is being built is launched, but that doesn't apply here either.

In any event, it is certainly the case that there is no need to configure the same root volume in the same way in both the `launch_block_device_mappings` and `ami_block_device_mappings` blocks.

## 🧪 Testing ##

All automated tests pass.  I also tested this change as part of cisagov/kali-packer#134 and found that it produced an identical AMI whether the block was present or not.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.