### PR TITLE
Prefer `true`/`false` to `yes`/`no` in YAML files

### DIFF
--- a/src/aws.yml
+++ b/src/aws.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   name: AWS-specific roles
-  become: yes
+  become: true
   become_method: ansible.builtin.sudo
   tasks:
     - name: Install Amazon EFS utilities

--- a/src/base.yml
+++ b/src/base.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   name: Setup base image
-  become: yes
+  become: true
   become_method: ansible.builtin.sudo
   tasks:
     - name: Install and configure automated security updates

--- a/src/example.yml
+++ b/src/example.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   name: Project-specific roles
-  become: yes
+  become: true
   become_method: ansible.builtin.sudo
   tasks:
     # The cisagov/ansible-role-example Ansible role is just a no-op,

--- a/src/python.yml
+++ b/src/python.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   name: Install pip3/python3 and remove pip2/python2
-  become: yes
+  become: true
   become_method: ansible.builtin.sudo
   tasks:
     # If pip were to be installed first, then the OS _could_ pull

--- a/src/upgrade.yml
+++ b/src/upgrade.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   name: Upgrade base image
-  become: yes
+  become: true
   become_method: ansible.builtin.sudo
   tasks:
     - name: Upgrade all packages


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request modifies the Ansible configuration to prefer `true`/`false` to `yes`/`no` in YAML files.

> [!NOTE]
> I am not bumping the version because this change should not result in any changes to behavior.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I have voiced this preference in the past and we made this change for Ansible roles already in https://github.com/cisagov/skeleton-ansible-role/pull/157
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated testing passes.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
