### PR TITLE
Add two new repository labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -2,6 +2,9 @@
 # Rather than breaking up descriptions into multiline strings we disable that
 # specific rule in yamllint for this file.
 # yamllint disable rule:line-length
+- color: "f15a53"
+  description: Pull requests that update Ansible code
+  name: ansible
 - color: "eb6420"
   description: This issue or pull request is awaiting the outcome of another issue or pull request
   name: blocked
@@ -50,6 +53,9 @@
 - color: "fcdb45"
   description: This pull request is awaiting an action or decision to move forward
   name: on hold
+- color: "02a8ef"
+  description: Pull requests that update Packer code
+  name: packer
 - color: "ef476c"
   description: This issue is a request for information or needs discussion
   name: question


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds the `ansible` and `packer` labels to the [crazy-max/ghaction-github-labeler](https://github.com/crazy-max/ghaction-github-labeler) configuration.

> [!NOTE]
> I am not bumping the version because this pull request is a minor change to the GitHub Actions configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Since this project structure contains a Packer configuration that itself contains an Ansible configuration we should have labels available to indicate what is being changed.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. The [Action run](https://github.com/cisagov/skeleton-packer/actions/runs/6632081661/job/18016995604) shows these two labels would be created.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
