### PR TITLE
Bump the AWS Terraform provider to version 4.9

### DIFF
--- a/terraform-build-user/versions.tf
+++ b/terraform-build-user/versions.tf
@@ -6,12 +6,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 4.9"
     }
   }
 }

--- a/terraform-post-packer/versions.tf
+++ b/terraform-post-packer/versions.tf
@@ -6,12 +6,18 @@ terraform {
   # major version currently being used.  This practice will help us
   # avoid unwelcome surprises.
   required_providers {
-    # Version 3.38.0 of the Terraform AWS provider is the first
-    # version to support default tags.
-    # https://www.hashicorp.com/blog/default-tags-in-the-terraform-aws-provider
+    # Version 4.9 of the Terraform AWS provider made changes to the S3 bucket
+    # refactor that is in place for versions 4.0-4.8 of the provider. With v4.9
+    # only non-breaking changes and deprecation notices are introduced. Using
+    # this version will simplify migration to the new, broken out AWS S3 bucket
+    # configuration resources. Please see
+    # https://github.com/hashicorp/terraform-provider-aws/pull/23985
+    # for more information about the changes in v4.9 and
+    # https://www.hashicorp.com/blog/terraform-aws-provider-4-0-refactors-s3-bucket-resource
+    # for more information about the S3 bucket refactor.
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.38"
+      version = "~> 4.9"
     }
   }
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps the AWS Terraform provider to version 4.9.

## 💭 Motivation and context ##

This agrees with the changes in cisagov/skeleton-tf-module#188.  All children of this repo currently fail linting because they lack this change.

## 🧪 Testing ##

All automated tests pass.  They do not pass without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.