### PR TITLE
Pin the version of the `ansible` package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,18 @@
-ansible
+# With the release of version 2.10, Ansible finally correctly
+# identifies Kali Linux as being the Kali distribution of the Debian
+# OS family.  This simplifies a lot of things for roles that support
+# Kali Linux, so it makes sense to force the installation of Ansible
+# 2.10 or newer.
+#
+# We need at least version 6 to correctly identify Amazon Linux 2023
+# as using the dnf package manager, and version 8 is currently the
+# oldest supported version.
+#
+# We have tested against version 9.  We want to avoid automatically
+# jumping to another major version without testing, since there are
+# often breaking changes across major versions.  This is the reason
+# for the upper bound.
+ansible>=8,<10
 boto3
 docopt
 semver


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a version pin constraint for the [ansible] package in the requirements. This pin constraint matches the one in https://github.com/cisagov/skeleton-ansible-role/pull/173.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We should be mirroring the version of [ansible] used by [cisagov/skeleton-ansible-role] and its descendants to ensure consistency.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

This pull request needs #295 to pass tests. You can see everything working as expected in [this run](https://github.com/cisagov/skeleton-packer/actions/runs/8176929020) on a branch that combines both branches.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[ansible]: https://pypi.org/project/ansible/
[cisagov/skeleton-ansible-role]: https://github.com/cisagov/skeleton-ansible-role
