### PR TITLE
Pin the Python package `ansible-core` to earlier than 2.16.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@
 # for the upper bound.
 ansible>=8,<10
 # TODO: Remove this pin when possible.  See
-# cisagov/skeleton-packer##312 for more details.
+# cisagov/skeleton-packer#312 for more details.
 #
 # ansible-core 2.16.3 and later suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,9 @@
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
 ansible>=8,<10
+# TODO: Remove this pin when possible.  See
+# cisagov/skeleton-packer##312 for more details.
+#
 # ansible-core 2.16.3 and later suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,10 @@
 # often breaking changes across major versions.  This is the reason
 # for the upper bound.
 ansible>=8,<10
+# ansible-core 2.16.3 and later suffer from the bug discussed in
+# ansible/ansible#82702, which breaks any symlinked files in vars,
+# tasks, etc. for any Ansible role installed via ansible-galaxy.
+ansible-core<2.16.3
 boto3
 docopt
 semver

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,8 @@ ansible>=8,<10
 # ansible-core 2.16.3 and later suffer from the bug discussed in
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
+#
+# See also cisagov/skeleton-ansible-role#178.
 ansible-core<2.16.3
 boto3
 docopt


### PR DESCRIPTION
## 🗣 Description ##

This pull request pins the `ansible-core` Python package's version to earlier than 2.16.3.

## 💭 Motivation and context ##

`ansible-core` 2.16.3 and later suffer from the bug discussed in ansible/ansible#82702, which breaks any symlinked files in `vars`, `tasks`, etc. for any Ansible role installed via `ansible-galaxy`.  This results in [AMI build failures](https://github.com/cisagov/openvpn-packer/actions/runs/8205777362/job/22446435052) as seen in cisagov/openvpn-packer#101.

## 🧪 Testing ##

All automated testing passes in this pull request, and in cisagov/openvpn-packer#101 the build [gets further than it did upon addition of these changes](https://github.com/cisagov/openvpn-packer/actions/runs/8208824296/job/22453124370?pr=101).  (The build continues to fail, but for a different reason.)

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
