### PR TITLE
Add Dependabot ignore directives for `ansible` and `ansible-core`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       interval: weekly
 
   - directory: /
+    # ignore:
+    #   # Managed by cisagov/skeleton-packer
+    #     - dependency-name: ansible
+    #     - dependency-name: ansible-core
     package-ecosystem: pip
     schedule:
       interval: weekly


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a couple of missing Dependabot ignore directives.

## 💭 Motivation and context ##

The versions of these dependencies are controlled in this repo, so descendant repos should not be concerned about them.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.