### PR TITLE
Fix the formatting for commented out ignore directives

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,8 @@ updates:
   - directory: /
     # ignore:
     #   # Managed by cisagov/skeleton-packer
-    #     - dependency-name: ansible
-    #     - dependency-name: ansible-core
+    #   - dependency-name: ansible
+    #   - dependency-name: ansible-core
     package-ecosystem: pip
     schedule:
       interval: weekly


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adjust the formatting for the pip package ecosystem's commented out ignore directives.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

I was asleep at the wheel when reviewing #315 and missed the formatting. When you uncomment these directives downstream you get malformed YAML due to incorrect spacing.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I verified that it uncomments correctly and this also matches the formatting for all other commented out ignore directives in the file.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
