### PR TITLE
Add reminder that pin must be in sync with two other places

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,11 @@ ansible>=8,<10
 # ansible/ansible#82702, which breaks any symlinked files in vars,
 # tasks, etc. for any Ansible role installed via ansible-galaxy.
 #
-# See also cisagov/skeleton-ansible-role#178.
+# See also cisagov/skeleton-ansible-role#178 and
+# cisagov/skeleton-generic#180.  Note from these PRs that any changes
+# made to this dependency must also be made in requirements-test.txt
+# in cisagov/skeleton-ansible-role and .pre-commit-config.yaml in
+# cisagov/skeleton-generic.
 ansible-core<2.16.3
 boto3
 docopt


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies a comment to remind us that the `ansible-core` pin must stay in sync across this repo as well as:
- [cisagov/skeleton-generic](https://github.com/cisagov/skeleton-generic)
- [cisagov/skeleton-ansible-role](https://github.com/cisagov/skeleton-ansible-role)

## 💭 Motivation and context ##

If we update the pin in one place we must remember to update it in the two other places.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.