### PR TITLE
Check that file exists before attempting to move it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,10 @@ jobs:
             "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ZIP}"
           sudo unzip -d /opt/packer \
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
-          sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          if [ -e /usr/local/bin/packer ]
+          then
+            sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          fi
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -218,7 +221,10 @@ jobs:
             "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ZIP}"
           sudo unzip -d /opt/packer \
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
-          sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          if [ -e /usr/local/bin/packer ]
+          then
+            sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          fi
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
       - name: Install dependencies
         run: |
@@ -278,7 +284,10 @@ jobs:
             "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ZIP}"
           sudo unzip -d /opt/packer \
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
-          sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          if [ -e /usr/local/bin/packer ]
+          then
+            sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          fi
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -73,7 +73,10 @@ jobs:
             "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ZIP}"
           sudo unzip -d /opt/packer \
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
-          sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          if [ -e /usr/local/bin/packer ]
+          then
+            sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          fi
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
       - uses: hashicorp/setup-terraform@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,10 @@ jobs:
             "https://releases.hashicorp.com/packer/${PACKER_VERSION}/${PACKER_ZIP}"
           sudo unzip -d /opt/packer \
             ${{ env.CURL_CACHE_DIR }}/"${PACKER_ZIP}"
-          sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          if [ -e /usr/local/bin/packer ]
+          then
+            sudo mv /usr/local/bin/packer /usr/local/bin/packer-default
+          fi
           sudo ln -s /opt/packer/packer /usr/local/bin/packer
       - uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the GitHub workflows to verify that `/usr/local/bin/packer` exists before attempting to `mv` it.

## 💭 Motivation and context ##

Packer is not preinstalled on the `ubuntu-24.04` runner image, for example, so the previous code will result in an error there.

## 🧪 Testing ##

This change was tested as part of cisagov/freeipa-server-packer#133.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.