### PR TITLE
Add a comment explaining why we require `semver>=3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,7 @@ ansible>=10,<11
 ansible-core>=2.17
 boto3
 docopt
+# The bump-version script requires at least version 3 of semver.
 semver>=3
 setuptools
 wheel


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a comment explaining why we must pin `semver>=3`.

## 💭 Motivation and context ##

It is good to document these requirements so we don't wonder about them in the future.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.