### PR TITLE
Take into account new Parameter Store parameter containing name of third-party bucket

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -244,10 +244,12 @@ jobs:
           - arm64
           - x86_64
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      # This job fails with the permissions monitoring in place,
+      # perhaps due to resource constraints on the free GH runners.
+      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      #   with:
+      #     # Uses the organization variable unless overridden
+      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,7 +307,21 @@ jobs:
           /usr/bin/python3
       - name: Install Packer plugins
         run: packer init .
+      # If the AMI to be built via Packer requires anything from the
+      # third-party bucket then you will require this step.
+      # - id: get-third-party-bucket-name
+      #   name: Get the third-party bucket name from SSM Parameter Store
+      #   run: |
+      #     echo name=$(aws ssm get-parameter \
+      #       --name /third_party_bucket_name \
+      #       --output text \
+      #       --query Parameter.Value \
+      #       --with-decryption) >> $GITHUB_OUTPUT
       - name: Create machine image
+        # Note that if you uncomment the get-third-party-bucket-name
+        # step above then you will likely need to add a line like
+        # this after -timestamp-ui \:
+        # -var build_bucket=${{ steps.get-third-party-bucket-name.outputs.name }} \
         run: |
           packer build -only amazon-ebs.${{ matrix.architecture }} \
             -timestamp-ui \

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -51,10 +51,12 @@ jobs:
           - arm64
           - x86_64
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      # This job fails with the permissions monitoring in place,
+      # perhaps due to resource constraints on the free GH runners.
+      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      #   with:
+      #     # Uses the organization variable unless overridden
+      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -114,7 +114,21 @@ jobs:
           /usr/bin/python3
       - name: Install Packer plugins
         run: packer init .
+      # If the AMI to be built via Packer requires anything from the
+      # third-party bucket then you will require this step.
+      # - id: get-third-party-bucket-name
+      #   name: Get the third-party bucket name from SSM Parameter Store
+      #   run: |
+      #     echo name=$(aws ssm get-parameter \
+      #       --name /third_party_bucket_name \
+      #       --output text \
+      #       --query Parameter.Value \
+      #       --with-decryption) >> $GITHUB_OUTPUT
       - name: Create machine image
+        # Note that if you uncomment the get-third-party-bucket-name
+        # step above then you will likely need to add a line like
+        # this after -timestamp-ui \:
+        # -var build_bucket=${{ steps.get-third-party-bucket-name.outputs.name }} \
         run: |
           packer build -only amazon-ebs.${{ matrix.architecture }} \
             -timestamp-ui \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,10 +58,12 @@ jobs:
           - arm64
           - x86_64
     steps:
-      - uses: GitHubSecurityLab/actions-permissions/monitor@v1
-        with:
-          # Uses the organization variable unless overridden
-          config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
+      # This job fails with the permissions monitoring in place,
+      # perhaps due to resource constraints on the free GH runners.
+      # - uses: GitHubSecurityLab/actions-permissions/monitor@v1
+      #   with:
+      #     # Uses the organization variable unless overridden
+      #     config: ${{ vars.ACTIONS_PERMISSIONS_CONFIG }}
       - id: harden-runner
         name: Harden the runner
         uses: step-security/harden-runner@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,21 @@ jobs:
           /usr/bin/python3
       - name: Install Packer plugins
         run: packer init .
+      # If the AMI to be built via Packer requires anything from the
+      # third-party bucket then you will require this step.
+      # - id: get-third-party-bucket-name
+      #   name: Get the third-party bucket name from SSM Parameter Store
+      #   run: |
+      #     echo name=$(aws ssm get-parameter \
+      #       --name /third_party_bucket_name \
+      #       --output text \
+      #       --query Parameter.Value \
+      #       --with-decryption) >> $GITHUB_OUTPUT
       - name: Create machine image
+        # Note that if you uncomment the get-third-party-bucket-name
+        # step above then you will likely need to add a line like
+        # this after -timestamp-ui \:
+        # -var build_bucket=${{ steps.get-third-party-bucket-name.outputs.name }} \
         run: |
           packer build -only amazon-ebs.${{ matrix.architecture }} \
             -timestamp-ui \

--- a/terraform-build-user/main.tf
+++ b/terraform-build-user/main.tf
@@ -7,6 +7,12 @@ module "iam_user" {
     aws.images-ssm = aws.images-ssm
   }
 
-  ssm_parameters = ["/cyhy/dev/users", "/ssh/public_keys/*"]
-  user_name      = "build-skeleton-packer"
+  ssm_parameters = [
+    "/cyhy/dev/users",
+    "/ssh/public_keys/*",
+    # Any Packer AMIs that require access to the third-party bucket
+    # will also require access to this SSM Parameter Store parameter.
+    # "/third_party_bucket_name",
+  ]
+  user_name = "build-skeleton-packer"
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Makes some changes to the GHA workflows and Terraform code to take into account the new Parameter Store parameter that contains the name of the third-party bucket
- Comments out the [GitHubSecurityLab/actions-permissions/monitor](https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor) step in relevant workflows.

## 💭 Motivation and context ##

- We have changed the way we handle this piece of information, and our Packer AMI builds must also change if they are to continue building.
- These steps fail with the permissions monitoring in place, perhaps due to resource constraints on the free GH runners.

## 🧪 Testing ##

All automated tests pass.  I had previously made these changes to cisagov/teamserver-packer#99 in order to test them, and [the `build.yml` workflow functioned as expected](https://github.com/cisagov/teamserver-packer/actions/runs/13818241133).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.