### PR TITLE
Add Terraform docs for build user and post-Packer code

### DIFF
--- a/terraform-build-user/.terraform-docs.yml
+++ b/terraform-build-user/.terraform-docs.yml
@@ -1,0 +1,1 @@
+../.terraform-docs.yml

--- a/terraform-build-user/README.md
+++ b/terraform-build-user/README.md
@@ -1,0 +1,50 @@
+# Build User #
+
+This directory consists of [Terraform](https://www.terraform.io/) code
+that is used to create a build user.  This build user is in turn used
+by our CI/CD pipeline to create AMIs via [Packer](https://packer.io)
+for our various COOL environments.
+
+See [the overall project documentation](../README.md) for a detailed
+description of how this code is intended to be used.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 1.0 |
+| aws | ~> 4.9 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws.cool-terraform-backend | ~> 4.9 |
+| terraform | n/a |
+
+## Modules ##
+
+| Name | Source | Version |
+|------|--------|---------|
+| iam\_user | github.com/cisagov/ami-build-iam-user-tf-module | n/a |
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| [aws_caller_identity.terraform_backend](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [terraform_remote_state.images](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.images_parameterstore](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+| [terraform_remote_state.users](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs ##
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
+
+## Outputs ##
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform-post-packer/.terraform-docs.yml
+++ b/terraform-post-packer/.terraform-docs.yml
@@ -1,0 +1,1 @@
+../.terraform-docs.yml

--- a/terraform-post-packer/README.md
+++ b/terraform-post-packer/README.md
@@ -1,0 +1,54 @@
+# Post-Packer #
+
+This directory consists of [Terraform](https://www.terraform.io/) code
+that is used to share AMIs with the appropriate AWS accounts.  This
+code is intended to be run after the CI/CD pipeline has created a new
+AMI for a COOL environment.
+
+See [the overall project documentation](../README.md) for more
+details.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements ##
+
+| Name | Version |
+|------|---------|
+| terraform | ~> 1.0 |
+| aws | ~> 4.9 |
+
+## Providers ##
+
+| Name | Version |
+|------|---------|
+| aws | ~> 4.9 |
+
+## Modules ##
+
+| Name | Source | Version |
+|------|--------|---------|
+| ami\_launch\_permission\_arm64 | github.com/cisagov/ami-launch-permission-tf-module | n/a |
+| ami\_launch\_permission\_x86\_64 | github.com/cisagov/ami-launch-permission-tf-module | n/a |
+
+## Resources ##
+
+| Name | Type |
+|------|------|
+| [aws_ami_ids.historical_amis_arm64](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids) | data source |
+| [aws_ami_ids.historical_amis_x86_64](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami_ids) | data source |
+| [aws_caller_identity.images](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+
+## Inputs ##
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| ami\_share\_account\_name\_regex | A regular expression that matches the names of AWS accounts with which to share the AMIs created by this repository.  This variable is used to share the AMIs with accounts that are members of the same AWS Organization as the account that owns the AMIs. | `string` | `"^env[[:digit:]]+$"` | no |
+| extraorg\_account\_ids | A list of AWS account IDs corresponding to "extra" accounts with which you want to share this AMI (e.g. ["123456789012"]).  Normally this variable is used to share an AMI with accounts that are not a member of the same AWS Organization as the account that owns the AMI. | `list(string)` | `[]` | no |
+| recent\_ami\_count | The number of most-recent AMIs (per architecture) for which to grant launch permission (e.g. "3").  If this variable is set to three, for example, then accounts will be granted permission to launch the three most recent AMIs (or all most recent AMIs, if there are only one or two of them in existence). | `number` | `12` | no |
+
+## Outputs ##
+
+| Name | Description |
+|------|-------------|
+| launch\_permissions\_arm64 | The cisagov/ami-launch-permission-tf-module for each ARM64 AMI to which launch permission is being granted. |
+| launch\_permissions\_x86\_64 | The cisagov/ami-launch-permission-tf-module for each x86\_64 AMI to which launch permission is being granted. |
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds Terraform documentation for the build user and post-Packer code.

## 💭 Motivation and context ##

Resolves #403.

## 🧪 Testing ##

All automated tests.  I inspected the rendered Markdown and it looks good to me.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.