### PR TITLE
Remove dollar sign from end of account name regex default value

### DIFF
--- a/terraform-post-packer/variables.tf
+++ b/terraform-post-packer/variables.tf
@@ -5,7 +5,7 @@
 # ------------------------------------------------------------------------------
 
 variable "ami_share_account_name_regex" {
-  default     = "^env[[:digit:]]+$"
+  default     = "^env[[:digit:]]+"
   description = "A regular expression that matches the names of AWS accounts with which to share the AMIs created by this repository.  This variable is used to share the AMIs with accounts that are members of the same AWS Organization as the account that owns the AMIs."
   type        = string
 }


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes a dollar sign from the end of the `ami_share_account_name_regex` variable's default value in the `terraform-post-packer` code.

## 💭 Motivation and context ##

With the dollar sign in place the regex does not match the names of the accounts in our COOL production environment.

## 🧪 Testing ##

All automated tests pass.  I verified that this change is indeed necessary when running the `terraform-post-packer` code after creating a release as part of #420.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.