### PR TITLE
Bake Ansible requirements installation into the template

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -346,8 +346,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade \
                       --requirement requirements.txt
-      - name: Install Ansible roles
-        run: ansible-galaxy install --force --role-file ansible/requirements.yml
       - name: Assume AWS build role
         uses: aws-actions/configure-aws-credentials@v4.2.1
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -120,8 +120,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade \
                       --requirement requirements.txt
-      - name: Install Ansible roles
-        run: ansible-galaxy install --force --role-file ansible/requirements.yml
       - name: Assume AWS build role
         uses: aws-actions/configure-aws-credentials@v4.2.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,8 +127,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade \
                       --requirement requirements.txt
-      - name: Install Ansible roles
-        run: ansible-galaxy install --force --role-file ansible/requirements.yml
       # Do not copy the AMI to other regions until we have figured out a
       # workable mechanism for creating and managing AMI KMS keys in other
       # regions.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,8 @@ No modules.
 | ami\_regions | The list of AWS regions to copy the AMI to once it has been created. Example: ["us-east-1"] | `list(string)` | `[]` | no |
 | build\_region | The region in which to retrieve the base AMI from and build the new AMI. | `string` | `"us-east-1"` | no |
 | build\_region\_kms | The ID or ARN of the KMS key to use for AMI encryption. | `string` | `"alias/cool-amis"` | no |
+| force\_install\_ansible\_requirements | Indicate if the Ansible requirements should be force installed. | `bool` | `false` | no |
+| force\_install\_ansible\_requirements\_with\_dependencies | Indicate if the Ansible requirements *and* their dependencies should be force installed. | `bool` | `false` | no |
 | github\_ref\_name | The GitHub short ref name to use for the tags applied to the created AMI. | `string` | `""` | no |
 | github\_sha | The GitHub commit SHA to use for the tags applied to the created AMI. | `string` | `""` | no |
 | is\_prerelease | The pre-release status to use for the tags applied to the created AMI. | `bool` | `false` | no |

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -5,10 +5,12 @@ build {
   ]
 
   provisioner "ansible" {
-    galaxy_file   = "ansible/requirements.yml"
-    playbook_file = "ansible/upgrade.yml"
-    use_proxy     = false
-    use_sftp      = true
+    galaxy_file            = "ansible/requirements.yml"
+    galaxy_force_install   = var.force_install_ansible_requirements
+    galaxy_force_with_deps = var.force_install_ansible_requirements_with_dependencies
+    playbook_file          = "ansible/upgrade.yml"
+    use_proxy              = false
+    use_sftp               = true
   }
 
   provisioner "ansible" {

--- a/build.pkr.hcl
+++ b/build.pkr.hcl
@@ -5,6 +5,7 @@ build {
   ]
 
   provisioner "ansible" {
+    galaxy_file   = "ansible/requirements.yml"
     playbook_file = "ansible/upgrade.yml"
     use_proxy     = false
     use_sftp      = true

--- a/variables.pkr.hcl
+++ b/variables.pkr.hcl
@@ -28,6 +28,18 @@ variable "build_region_kms" {
   type        = string
 }
 
+variable "force_install_ansible_requirements" {
+  default     = false
+  description = "Indicate if the Ansible requirements should be force installed."
+  type        = bool
+}
+
+variable "force_install_ansible_requirements_with_dependencies" {
+  default     = false
+  description = "Indicate if the Ansible requirements *and* their dependencies should be force installed."
+  type        = bool
+}
+
 variable "github_ref_name" {
   default     = ""
   description = "The GitHub short ref name to use for the tags applied to the created AMI."


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request modifies the Packer template to install Ansible requirements as part of the first `ansible` provisioner. This allows us to remove the Ansible requirement installation step from the GitHub Actions workflow jobs that build AMIs (it is still necessary for the `lint` job).
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Making Ansible requirement installation part of the template helps ensure that even if the template is used outside of our GitHub Actions configuration these requirements are installed appropriately.

> [!NOTE]
> Although the template is being modified I do not believe these changes would trigger a version bump. If the team feels otherwise please mention so and I'll be happy to bump the version.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I also verified that the provisioner installs the Ansible requirements [here](https://github.com/cisagov/skeleton-packer/actions/runs/15491744873/job/43618990804#step:14:49):

```log
2025-06-06T13:37:14Z:     amazon-ebs.x86_64: Executing Ansible Galaxy
2025-06-06T13:37:19Z:     amazon-ebs.x86_64: Starting galaxy role install process
2025-06-06T13:37:19Z:     amazon-ebs.x86_64: - extracting amazon_efs_utils to /home/runner/.ansible/roles/amazon_efs_utils
2025-06-06T13:37:19Z:     amazon-ebs.x86_64: - amazon_efs_utils was installed successfully
...
```
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
