### PR TITLE
Use a GitHub token when running `packer init`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,13 @@ defaults:
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  # We have seen some failures of packer init in GitHub Actions due to
+  # rate limiting when pulling Packer plugins from GitHub.  Having
+  # Packer use a GitHub API token should reduce this.  The rate
+  # limiting for unauthenticated requests is 60 requests/hour while
+  # the rate limiting for authenticated requests is 5000
+  # requests/hour.
+  PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PIP_CACHE_DIR: ~/.cache/pip
   PRE_COMMIT_CACHE_DIR: ~/.cache/pre-commit
   RUN_TMATE: ${{ secrets.RUN_TMATE }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,6 +8,13 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  # We have seen some failures of packer init in GitHub Actions due to
+  # rate limiting when pulling Packer plugins from GitHub.  Having
+  # Packer use a GitHub API token should reduce this.  The rate
+  # limiting for unauthenticated requests is 60 requests/hour while
+  # the rate limiting for authenticated requests is 5000
+  # requests/hour.
+  PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   PIP_CACHE_DIR: ~/.cache/pip
   RUN_TMATE: ${{ secrets.RUN_TMATE }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,13 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   AWS_DEFAULT_REGION: us-east-1
+  # We have seen some failures of packer init in GitHub Actions due to
+  # rate limiting when pulling Packer plugins from GitHub.  Having
+  # Packer use a GitHub API token should reduce this.  The rate
+  # limiting for unauthenticated requests is 60 requests/hour while
+  # the rate limiting for authenticated requests is 5000
+  # requests/hour.
+  PACKER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   # Do not copy the AMI to other regions until we have figured out a
   # workable mechanism for creating and managing AMI KMS keys in other
   # regions.


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `build.yml`, `prerelease.yml`, and `release.yml` workflows to set the `PACKER_GITHUB_API_TOKEN` environment variable.  This allows `packer` commands to make authenticated requests to GitHub.

## 💭 Motivation and context ##

We have seen some failures of `packer init` in GitHub Actions due to rate limiting when pulling Packer plugins from GitHub.  See, e.g., [this job](https://github.com/cisagov/debian-packer/actions/runs/16280980497/job/45970661301).

Having Packer use a GitHub API token should reduce this.  The rate limit for _unauthenticated_ requests is 60 requests/hour while the rate limiting for _authenticated_ requests is 5000 requests/hour.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
