### PR TITLE
Ignore vulnerability when running `pip-audit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -172,6 +172,19 @@ repos:
           # cisagov/skeleton-packer#380 for more details.
           - --ignore-vuln
           - GHSA-99w6-3xph-cx78
+          # We have to ignore this vulnerability since we need to pin
+          # to ansible 10 for now to support our CyHy code that must
+          # still run on Debian Buster.  This vulnerability is fixed
+          # in ansible>=12.
+          #
+          # This isn't a big deal since the vulnerability only impacts
+          # users of the Keycloak modules in
+          # ansible.community.general, and we don't use these modules.
+          #
+          # TODO: Remove this when it becomes possible.  See
+          # cisagov/skeleton-packer#486 for more details.
+          - --ignore-vuln
+          - GHSA-8ggh-xwr9-3373
           # Add any pip requirements files to scan
           - --requirement
           - requirements-dev.txt


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds updates the `pip-audit` `pre-commit` hook configuration to ignore the [GHSA-8ggh-xwr9-3373](https://github.com/advisories/GHSA-8ggh-xwr9-3373) finding.

## 💭 Motivation and context ##

We have to ignore this vulnerability for now since we need to pin to `ansible>=10,<11` for now to support our CyHy code that must still run on Debian Buster.  This vulnerability is fixed in `ansible>=12`.

Ignoring this vulnerability isn't a big deal, since it only impacts users of the Keycloak modules in `ansible.community.general` and we don't use these modules.

## 🧪 Testing ##

All automated tests pass; `pre-commit` does not pass without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.