### PR TITLE
Group Dependabot updates for AWS Terraform provider

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,15 +43,9 @@ updates:
     schedule:
       interval: weekly
 
-  - directory: /terraform-build-user
-    # ignore:
-    #   # Managed by cisagov/skeleton-packer
-    #   - dependency-name: hashicorp/aws
-    package-ecosystem: terraform
-    schedule:
-      interval: weekly
-
-  - directory: /terraform-post-packer
+  - directories:
+      - /terraform-build-user
+      - /terraform-post-packer
     # ignore:
     #   # Managed by cisagov/skeleton-packer
     #   - dependency-name: hashicorp/aws


### PR DESCRIPTION
## 🗣 Description ##

This pull request updates the Dependabot configuration to group updates for the AWS Terraform provider.

## 💭 Motivation and context ##

This change will result in us getting a single Dependabot-generated PR for both `terraform-build-user` and `terraform-post-packer` when a new version of the AWS provider is released.  In every descendant repo these two Terraform root modules use the same version of the AWS provider; if we ever need to treat them separately in a repo then that repo can have its Dependabot configuration be the exception to the rule.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.  (There aren't any existing labels that apply.)
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.