### PR TITLE
Remove `boto3` and `docopt` from `requirements.txt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,20 @@ next steps. Note that you will need to know where your team stores their
 remote profile data in order to use
 [`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync).
 
+> [!IMPORTANT]
+> `boto3` is not a Python dependency that is used in this repository,
+> but it is often required in a repository of this type, e.g., when
+> using the `amazon.aws.aws_ssm` Ansible lookup plugin to pull a
+> parameter value from AWS Parameter Store.  In such a case you will
+> want to add `boto3` to the list of Python dependencies in
+> [`requirements.txt`](requirements.txt).
+>
+> For the same reason, unless you are using the
+> `community.general.json_query` Ansible filter, there is a good
+> chance that you do not need the `jmespath` Python dependency that is
+> included in [`requirements.txt`](requirements.txt).  In such a case
+> this dependency can be removed from that file.
+
 ### Creating a build user ###
 
 You will need to create a build user for each environment that you use.  The

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,6 @@ ansible>=10,<11
 # requirements-test.txt in cisagov/skeleton-ansible-role and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
 ansible-core>=2.17.7
-boto3
-docopt
 # The bump-version script requires at least version 3 of semver.
 semver>=3
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,10 @@ ansible>=10,<11
 # requirements-test.txt in cisagov/skeleton-ansible-role and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
 ansible-core>=2.17.7
+# This dependency is not used in this repository but is often required
+# in a repo of this type, e.g., when using the amazon.aws.aws_ssm
+# Ansible plugin to pull a parameter value from AWS Parameter Store.
+# boto3
 # Required because we are using the community.general.json_query filter in our Ansible
 # code in the cisagov/ansible-role-amazon-efs-utils role:
 # https://docs.ansible.com/projects/ansible/latest/collections/community/general/json_query_filter.html

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,10 @@ ansible>=10,<11
 # requirements-test.txt in cisagov/skeleton-ansible-role and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
 ansible-core>=2.17.7
+# Required because we are using the community.general.json_query filter in our Ansible
+# code in the cisagov/ansible-role-amazon-efs-utils role:
+# https://docs.ansible.com/projects/ansible/latest/collections/community/general/json_query_filter.html
+jmespath
 # The bump-version script requires at least version 3 of semver.
 semver>=3
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ ansible>=10,<11
 ansible-core>=2.17.7
 # This dependency is not used in this repository but is often required
 # in a repo of this type, e.g., when using the amazon.aws.aws_ssm
-# Ansible plugin to pull a parameter value from AWS Parameter Store.
+# Ansible lookup plugin to pull a parameter value from AWS Parameter
+# Store.
 # boto3
 # Required because we are using the community.general.json_query filter in our Ansible
 # code in the cisagov/ansible-role-amazon-efs-utils role:


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the `boto3` and `docopt` dependencies from `requirements.txt`.

## 💭 Motivation and context ##

These dependencies are not used anywhere in this repo and hence are unnecessary.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.