### PR TITLE
Bump up the instance types used to build the AMIs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,12 +9,6 @@
 # the repository and any of its subdirectories.
 /.github/ @dav3r @felddy @jsf9k @mcdonnnj
 
-# Let jsf9k own the sometimes-touchy AWS and Python playbooks, as well
-# as the Packer template.
-/*.pkr.hcl @jsf9k
-/ansible/aws.yml @jsf9k
-/ansible/python.yml @jsf9k
-
 # These folks own all linting configuration files.
 /.ansible-lint @dav3r @felddy @jsf9k @mcdonnnj
 /.bandit.yml @dav3r @felddy @jsf9k @mcdonnnj

--- a/ami_arm64.pkr.hcl
+++ b/ami_arm64.pkr.hcl
@@ -3,7 +3,7 @@ source "amazon-ebs" "arm64" {
   ami_regions                 = var.ami_regions
   associate_public_ip_address = true
   encrypt_boot                = true
-  instance_type               = "t4g.small"
+  instance_type               = "t4g.large"
   kms_key_id                  = var.build_region_kms
   launch_block_device_mappings {
     delete_on_termination = true

--- a/ami_x86_64.pkr.hcl
+++ b/ami_x86_64.pkr.hcl
@@ -3,7 +3,7 @@ source "amazon-ebs" "x86_64" {
   ami_regions                 = var.ami_regions
   associate_public_ip_address = true
   encrypt_boot                = true
-  instance_type               = "t3.small"
+  instance_type               = "t3.large"
   kms_key_id                  = var.build_region_kms
   launch_block_device_mappings {
     delete_on_termination = true


### PR DESCRIPTION
## 🗣 Description ##

This pull request bumps up the instance types used to build the AMIs from `t3.small` and `t4g.small` to `t3.large` and `t4g.large`, respectively.  It also changes the codeowners of some files from solely @jsf9k to the entire dev team (@cisagov/vm-dev).

## 💭 Motivation and context ##

The `t3.small` and `t4g.small` instance types have insufficient memory to build the Debian/RPM packages for [aws/efs-utils](https://github.com/aws/efs-utils), which results in [build failures](https://github.com/cisagov/skeleton-packer/actions/runs/21699056988).

I tried using `t3.medium` and `t4g.medium` instance types, but then building the Debian/RPM packages takes half an hour.  With the `t3.large` and `t4g.large` instance types it only takes 15 minutes.

Regarding the files for which additional codeowners were added, they haven't been problematic in years and hence there is no reason why @cisagov/vm-dev can't own these files as a group.

## 🧪 Testing ##

All automated tests pass with this change.  The same tests [do not pass](https://github.com/cisagov/skeleton-packer/actions/runs/21699056988) without this change.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
