### PR TITLE
Add some missing collections

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,7 +205,13 @@ jobs:
           python -m pip install --upgrade pip setuptools
           pip install --upgrade --requirement requirements-test.txt
       - name: Install Ansible roles
-        run: ansible-galaxy install --force --role-file ansible/requirements.yml
+        run: >-
+          ansible-galaxy role install --force
+          --role-file ansible/requirements.yml
+      - name: Install Ansible collections
+        run: >-
+          ansible-galaxy collection install --force
+          --requirements-file ansible/requirements.yml
       # This must happen before pre-commit is run or the Packer format
       # linter will throw an error.
       - name: Install Packer plugins

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,35 +1,45 @@
 ---
-- name: amazon_efs_utils
-  src: https://github.com/cisagov/ansible-role-amazon-efs-utils
-- name: amazon_ssm_agent
-  src: https://github.com/cisagov/ansible-role-amazon-ssm-agent
-- name: automated_security_updates
-  src: https://github.com/cisagov/ansible-role-automated-security-updates
-- name: banner
-  src: https://github.com/cisagov/ansible-role-banner
-- name: clamav
-  src: https://github.com/cisagov/ansible-role-clamav
-- name: cloudwatch_agent
-  src: https://github.com/cisagov/ansible-role-cloudwatch-agent
-- name: example
-  src: https://github.com/cisagov/skeleton-ansible-role
-- name: htop
-  src: https://github.com/cisagov/ansible-role-htop
-- name: nvme
-  src: https://github.com/cisagov/ansible-role-nvme
-- name: persist_journald
-  src: https://github.com/cisagov/ansible-role-persist-journald
-- name: pip
-  src: https://github.com/cisagov/ansible-role-pip
-- name: python
-  src: https://github.com/cisagov/ansible-role-python
-- name: remove_python2
-  src: https://github.com/cisagov/ansible-role-remove-python2
-- name: systemd_resolved
-  src: https://github.com/cisagov/ansible-role-systemd-resolved
-- name: systemd_timesyncd_aws
-  src: https://github.com/cisagov/ansible-role-systemd-timesyncd-aws
-- name: upgrade
-  src: https://github.com/cisagov/ansible-role-upgrade
-- name: wazuh_agent
-  src: https://github.com/cisagov/ansible-role-wazuh-agent
+collections:
+  # Required because we are using the amazon.aws.aws_ssm Ansible
+  # lookup plugin to pull parameters value from AWS Parameter Store.
+  - amazon.aws
+  # Required because we are using the community.general.json_query
+  # filter in our Ansible code in the
+  # cisagov/ansible-role-amazon-efs-utils role:
+  # https://docs.ansible.com/projects/ansible/latest/collections/community/general/json_query_filter.html
+  - community.general
+roles:
+  - name: amazon_efs_utils
+    src: https://github.com/cisagov/ansible-role-amazon-efs-utils
+  - name: amazon_ssm_agent
+    src: https://github.com/cisagov/ansible-role-amazon-ssm-agent
+  - name: automated_security_updates
+    src: https://github.com/cisagov/ansible-role-automated-security-updates
+  - name: banner
+    src: https://github.com/cisagov/ansible-role-banner
+  - name: clamav
+    src: https://github.com/cisagov/ansible-role-clamav
+  - name: cloudwatch_agent
+    src: https://github.com/cisagov/ansible-role-cloudwatch-agent
+  - name: example
+    src: https://github.com/cisagov/skeleton-ansible-role
+  - name: htop
+    src: https://github.com/cisagov/ansible-role-htop
+  - name: nvme
+    src: https://github.com/cisagov/ansible-role-nvme
+  - name: persist_journald
+    src: https://github.com/cisagov/ansible-role-persist-journald
+  - name: pip
+    src: https://github.com/cisagov/ansible-role-pip
+  - name: python
+    src: https://github.com/cisagov/ansible-role-python
+  - name: remove_python2
+    src: https://github.com/cisagov/ansible-role-remove-python2
+  - name: systemd_resolved
+    src: https://github.com/cisagov/ansible-role-systemd-resolved
+  - name: systemd_timesyncd_aws
+    src: https://github.com/cisagov/ansible-role-systemd-timesyncd-aws
+  - name: upgrade
+    src: https://github.com/cisagov/ansible-role-upgrade
+  - name: wazuh_agent
+    src: https://github.com/cisagov/ansible-role-wazuh-agent

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,7 +1,7 @@
 ---
 collections:
   # Required because we are using the amazon.aws.ssm_parameter Ansible
-  # lookup plugin to pull parameters value from AWS Parameter Store.
+  # lookup plugin to pull parameter values from AWS Parameter Store.
   - amazon.aws
   # Required by the following Ansible roles:
   # - ansible-role-amazon-efs-utils (uses community.general.json_query

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,12 +1,16 @@
 ---
 collections:
-  # Required because we are using the amazon.aws.aws_ssm Ansible
+  # Required because we are using the amazon.aws.ssm_parameter Ansible
   # lookup plugin to pull parameters value from AWS Parameter Store.
   - amazon.aws
-  # Required because we are using the community.general.json_query
-  # filter in our Ansible code in the
-  # cisagov/ansible-role-amazon-efs-utils role:
-  # https://docs.ansible.com/projects/ansible/latest/collections/community/general/json_query_filter.html
+  # Required by the following Ansible roles:
+  # - ansible-role-amazon-efs-utils (uses community.general.json_query
+  #   and community.general.make)
+  # - ansible-role-amazon-ssm-agent (uses community.general.snap)
+  # - ansible-role-automated-security-updates (uses community.general.ini_file)
+  # - ansible-role-cloudwatch-agent (uses community.general.ini_file)
+  # - ansible-role-persist-journald (uses community.general.ini_file)
+  # - ansible-role-systemd-resolved (uses community.general.ini_file)
   - community.general
 roles:
   - name: amazon_efs_utils

--- a/ansible/wazuh_agent.yml
+++ b/ansible/wazuh_agent.yml
@@ -10,4 +10,4 @@
       vars:
         # The IP or hostname of the Wazuh manager
         wazuh_agent_manager: >-
-          {{ lookup('amazon.aws.aws_ssm', '/wazuh_agent/manager') }}
+          {{ lookup('amazon.aws.ssm_parameter', '/wazuh_agent/manager') }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,9 @@ ansible>=10,<11
 # requirements-test.txt in cisagov/skeleton-ansible-role and
 # .pre-commit-config.yaml in cisagov/skeleton-generic.
 ansible-core>=2.17.7
-# Required because we are using the amazon.aws.aws_ssm Ansible lookup
-# plugin to pull parameters value from AWS Parameter Store.
+# Required because we are using the amazon.aws.ssm_parameter Ansible
+# lookup plugin to pull parameters value from AWS Parameter Store:
+# https://docs.ansible.com/projects/ansible/latest/collections/amazon/aws/ssm_parameter_lookup.html#ansible-collections-amazon-aws-ssm-parameter-lookup
 boto3
 # Required because we are using the community.general.json_query
 # filter in our Ansible code in the


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Adds two missing collections to the Ansible dependencies
- Fleshes out the comments describing why the collections are required
- Updates the code to stop using the old name for `amazon.aws.ssm_parameter`

## 💭 Motivation and context ##

These collections are required for the `amazon.aws.ssm_parameter` lookup plugin and the `community.general.json_query` filter, as well as for some of the Ansible roles that are used.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
