### PR TITLE
Update `ansible-galaxy` instructions to include installation of both roles and collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,11 @@ remote profile data in order to use
 [`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync).
 
 > [!IMPORTANT]
-> `boto3` is not a Python dependency that is used in this repository,
-> but it is often required in a repository of this type, e.g., when
-> using the `amazon.aws.aws_ssm` Ansible lookup plugin to pull a
-> parameter value from AWS Parameter Store.  In such a case you will
-> want to add `boto3` to the list of Python dependencies in
-> [`requirements.txt`](requirements.txt).
->
-> For the same reason, unless you are using the
-> `community.general.json_query` Ansible filter, there is a good
-> chance that you do not need the `jmespath` Python dependency that is
-> included in [`requirements.txt`](requirements.txt).  In such a case
-> this dependency can be removed from that file.
+> Unless you are using the `community.general.json_query` Ansible
+> filter, there is a good chance that you do not need the `jmespath`
+> Python dependency that is included in
+> [`requirements.txt`](requirements.txt).  In such a case this
+> dependency can be removed from that file.
 
 ### Creating a build user ###
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,8 @@ Here is an example of how to kick off a pre-release build:
 
 ```console
 pip install --requirement requirements-dev.txt
-ansible-galaxy install --force --force-with-deps --role-file ansible/requirements.yml
+ansible-galaxy role install --force --force-with-deps --role-file ansible/requirements.yml
+ansible-galaxy collection install --force --force-with-deps --requirements-file ansible/requirements.yml
 AWS_PROFILE=cool-images-ec2amicreate-skeleton-packer packer build --timestamp-ui -var release_tag=$(./bump-version show) -var is_prerelease=true .
 ```
 

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,4 +1,8 @@
 ---
+# Both the collections and roles lists must exist in this file because
+# we use both ansible-galaxy collection install and ansible-galaxy
+# role install to install collections and roles from it.  Note that
+# either (or both) can be an empty list, e.g., collections: [].
 collections:
   # Required because we are using the amazon.aws.ssm_parameter Ansible
   # lookup plugin to pull parameter values from AWS Parameter Store.


### PR DESCRIPTION
## 🗣 Description ##

This pull request:
- Removes a blurb about `boto3` being commonly needed for repos of this type
- Updates the  `ansible-galaxy` instructions to include installation of both roles and collections

## 💭 Motivation and context ##

- `boto3` is an actual dependency of this repo as of #510 and #513
- We install both roles and collections on our GitHub workflow, so we should do so in the manual instructions as well.  See https://github.com/cisagov/freeipa-server-packer/pull/158#discussion_r2884910103.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.