### PR TITLE
Ensure that the Terraform AWS provider PRs are grouped together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,10 @@ updates:
   - directories:
       - /terraform-build-user
       - /terraform-post-packer
+    groups:
+      aws-provider:
+        patterns:
+          - hashicorp/aws
     # ignore:
     #   # Managed by cisagov/skeleton-packer
     #   - dependency-name: hashicorp/aws


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a `groups` key to the Terraform Dependabot configuration to ensure that the Terraform AWS provider PRs generated by Dependabot for the `terraform-build-user` and `terraform-post-packer` directories are grouped together.

## 💭 Motivation and context ##

This was the intent of cisagov/skeleton-packer#498, but it failed to achieve it.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
