### PR TITLE
Tweak comment for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ remote profile data in order to use
 
 > [!IMPORTANT]
 > Unless you are using the `community.general.json_query` Ansible
-> filter, there is a good chance that you do not need the `jmespath`
+> filter (for example, via the
+> [cisagov/ansible-role-amazon-efs-utils](https://github.com/cisagov/ansible-role-amazon-efs-utils)
+> role), there is a good chance that you do not need the `jmespath`
 > Python dependency that is included in
 > [`requirements.txt`](requirements.txt).  In such a case this
 > dependency can be removed from that file.


### PR DESCRIPTION
## 🗣 Description ##

This pull request tweaks a comment to mention the specific role that makes use of `community.general.json_query`.

## 💭 Motivation and context ##

This is done to make it easier for the user to determine whether the `jmespath` Python dependency is necessary.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
