### PR TITLE
Explain why we use `--force-with-deps` when running Packer manually

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,9 @@ AWS_PROFILE=cool-images-ec2amicreate-skeleton-packer packer build --timestamp-ui
 > [!NOTE]
 > Note that we use `--force-with-deps` here since the user's Ansible
 > setup, unlike when we run in GitHub Actions, may not start from a
-> pristine state.  We want to make sure that the latest versions of
-> all Ansible roles and their dependencies are installed.
+> pristine state. We want to make sure that the latest versions of
+> all Ansible roles and collections, along with their dependencies, are
+> installed by forcing their reinstallation even if they are already present.
 
 If you are satisfied with your pre-release image, you can easily create a release
 that deploys to all regions by adding additional regions to the Packer template.

--- a/README.md
+++ b/README.md
@@ -181,6 +181,12 @@ ansible-galaxy collection install --force --force-with-deps --requirements-file 
 AWS_PROFILE=cool-images-ec2amicreate-skeleton-packer packer build --timestamp-ui -var release_tag=$(./bump-version show) -var is_prerelease=true .
 ```
 
+> [!NOTE]
+> Note that we use `--force-with-deps` here since the user's Ansible
+> setup, unlike when we run in GitHub Actions, may not start from a
+> pristine state.  We want to make sure that the latest versions of
+> all Ansible roles and their dependencies are installed.
+
 If you are satisfied with your pre-release image, you can easily create a release
 that deploys to all regions by adding additional regions to the Packer template.
 This can be done by using a `.pkrvars.hcl` for example with `release.pkrvars.hcl`:


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a note to the README explaining why we use `--force-with-deps` when running Packer manually.

## 💭 Motivation and context ##

It is not necessary to use `--force-with-deps` when running in GitHub Actions (i.e. in the CLI code) because there we are starting from a known, pristine state.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.